### PR TITLE
Fix output buffer flushing.

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -34,6 +34,11 @@ TCPOutBufSize = 4096
 # The value of zero means no flushing.
 TCPOutBufFlushPeriodSec = 2
 
+# Maximum reconnection period to target host
+MaxHostReconnectPeriodMs = 5000
+# Parameter for exponential backoffs during reconnects
+HostReconnectPeriodDeltaMs = 10
+
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true
 # Turns on logging for special kinds of records. For now it's recrods with fractional timestamps.

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -24,7 +24,9 @@ type Main struct {
 	// 0 value turns off buffering
 	TCPOutBufSize int
 	// 0 value turns off flushing
-	TCPOutBufFlushPeriodSec uint32
+	TCPOutBufFlushPeriodSec    uint32
+	MaxHostReconnectPeriodMs   uint32
+	HostReconnectPeriodDeltaMs uint32
 
 	NormalizeRecords  bool
 	LogSpecialRecords bool
@@ -69,6 +71,8 @@ func MakeDefault() Main {
 		TermTimeoutSec:             10,
 		TCPOutBufSize:              0,
 		TCPOutBufFlushPeriodSec:    2,
+		MaxHostReconnectPeriodMs:   5000,
+		HostReconnectPeriodDeltaMs: 10,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -19,15 +19,16 @@ func TestConfSimple(t *testing.T) {
 	HostQueueSize = 10
 	WorkerPoolSize = 10
 	TCPOutBufSize = 11
-	TCPOutBufFlushPeriodSec = 3`
+	TCPOutBufFlushPeriodSec = 3
+	MaxHostReconnectPeriodMs = 777
+	HostReconnectPeriodDeltaMs = 13`
 
 	expected := Main{
 		ListeningPort: 2003,
 		TargetPort:    2008,
 
-		MainQueueSize: 100,
-		HostQueueSize: 10,
-
+		MainQueueSize:  100,
+		HostQueueSize:  10,
 		WorkerPoolSize: 10,
 
 		IncomingConnIdleTimeoutSec: 13,
@@ -36,6 +37,8 @@ func TestConfSimple(t *testing.T) {
 		TermTimeoutSec:             11,
 		TCPOutBufSize:              11,
 		TCPOutBufFlushPeriodSec:    3,
+		MaxHostReconnectPeriodMs:   777,
+		HostReconnectPeriodDeltaMs: 13,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -184,15 +184,13 @@ func (h *Host) Write(b []byte) (nn int, err error) {
 
 // Flush immediately flushes the buffer and performs a write
 func (h *Host) Flush(d time.Duration) {
-	if h.W != nil {
-		if h.W.Buffered() != 0 {
-			err := h.W.Flush()
-			if err != nil {
-				h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
-				// if flushing fails, the connection has to be re-established
-				h.Conn = nil
-				h.W = nil
-			}
+	if h.W == nil || h.W.Buffered() == 0 {
+		err := h.W.Flush()
+		if err != nil {
+			h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
+			// if flushing fails, the connection has to be re-established
+			h.Conn = nil
+			h.W = nil
 		}
 	}
 }

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -185,13 +185,14 @@ func (h *Host) Write(b []byte) (nn int, err error) {
 // Flush immediately flushes the buffer and performs a write
 func (h *Host) Flush(d time.Duration) {
 	if h.W == nil || h.W.Buffered() == 0 {
-		err := h.W.Flush()
-		if err != nil {
-			h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
-			// if flushing fails, the connection has to be re-established
-			h.Conn = nil
-			h.W = nil
-		}
+		return
+	}
+	err := h.W.Flush()
+	if err != nil {
+		h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
+		// if flushing fails, the connection has to be re-established
+		h.Conn = nil
+		h.W = nil
 	}
 }
 

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -24,7 +24,6 @@ type Host struct {
 	Conn net.Conn
 
 	W    *bufio.Writer
-	CWm  sync.Mutex // this is the mutex to lock connection and writer
 	stop chan int
 
 	Lg                      *zap.Logger
@@ -32,6 +31,8 @@ type Host struct {
 	SendTimeoutSec          uint32
 	ConnTimeoutSec          uint32
 	TCPOutBufFlushPeriodSec uint32
+	MaxReconnectPeriodMs    uint32
+	ReconnectPeriodDeltaMs  uint32
 
 	outRecs            prometheus.Counter
 	throttled          prometheus.Counter
@@ -64,6 +65,8 @@ func NewHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.L
 		throttled:               ms.ThrottledHosts.With(promLabels),
 		processingDuration:      ms.ProcessingDuration,
 		bufSize:                 mainCfg.TCPOutBufSize,
+		MaxReconnectPeriodMs:    mainCfg.MaxHostReconnectPeriodMs,
+		ReconnectPeriodDeltaMs:  mainCfg.MaxHostReconnectPeriodMs,
 	}
 }
 
@@ -76,105 +79,118 @@ func (h *Host) Push(r *rec.Rec) {
 	}
 }
 
+// OptionalTicker is a ticker that only starts if passed non-zero duration
+type OptionalTicker struct {
+	C <-chan time.Time
+	t *time.Ticker
+}
+
+func NewOptionalTicker(d time.Duration) *OptionalTicker {
+	var ticker OptionalTicker
+	if d != 0 {
+		ticker.t = time.NewTicker(d)
+		ticker.C = ticker.t.C
+	}
+
+	return &ticker
+}
+
+func (t *OptionalTicker) Stop() {
+	if t != nil {
+		t.Stop()
+	}
+}
+
 // Stream launches the the sending to target host.
 // Exits when queue is closed and sending is finished.
 func (h *Host) Stream(wg *sync.WaitGroup) {
 	// TODO (grzkv) Maybe move (re)connection to a separate goroutine and communicate via a chan
 
-	if h.TCPOutBufFlushPeriodSec != 0 {
-		go h.Flush(time.Second * time.Duration(h.TCPOutBufFlushPeriodSec))
-	}
+	ticker := NewOptionalTicker(time.Duration(h.TCPOutBufFlushPeriodSec))
+	defer ticker.Stop()
+
 	defer func() {
 		wg.Done()
 		close(h.stop)
 	}()
 
-	for r := range h.Ch {
-		// retry until successful
-		for {
-			const maxReconnectPeriodMs = 5000
-			const reconnectDeltaMs = 10
-			for reconnectWait := 0; h.Conn == nil; {
-				time.Sleep(time.Duration(reconnectWait) * time.Millisecond)
-				if reconnectWait < maxReconnectPeriodMs {
-					reconnectWait = reconnectWait*2 + reconnectDeltaMs
+	for {
+		select {
+		case r, ok := <-h.Ch:
+			if !ok {
+				return
+			}
+			// retry until successful
+			for {
+				h.reconnectIfNecessary()
+
+				err := h.Conn.SetWriteDeadline(time.Now().Add(
+					time.Duration(h.SendTimeoutSec) * time.Second))
+				if err != nil {
+					h.Lg.Warn("error setting write deadline. Renewing the connection.",
+						zap.Error(err))
 				}
-				if reconnectWait >= maxReconnectPeriodMs {
-					reconnectWait = maxReconnectPeriodMs
+
+				// this may loose one record on disconnect
+				_, err = h.Write([]byte(*r.Serialize()))
+
+				if err == nil {
+					h.outRecs.Inc()
+					h.processingDuration.Observe(time.Since(r.Received).Seconds())
+					break
 				}
 
-				h.Connect()
+				h.Lg.Warn("error sending value to host. Reconnect and retry..",
+					zap.String("target", h.Name),
+					zap.Uint16("port", h.Port),
+					zap.Error(err),
+				)
+				err = h.Conn.Close()
+				if err != nil {
+					// not retrying here, file descriptor may be lost
+					h.Lg.Error("error closing the connection",
+						zap.Error(err))
+				}
+
+				h.Conn = nil
 			}
-
-			h.CWm.Lock()
-			err := h.Conn.SetWriteDeadline(time.Now().Add(
-				time.Duration(h.SendTimeoutSec) * time.Second))
-			h.CWm.Unlock()
-			if err != nil {
-				h.Lg.Warn("error setting write deadline. Renewing the connection.",
-					zap.Error(err))
-			}
-
-			// this may loose one record on disconnect
-			_, err = h.Write([]byte(*r.Serialize()))
-
-			if err == nil {
-				h.outRecs.Inc()
-				h.processingDuration.Observe(time.Since(r.Received).Seconds())
-				break
-			}
-
-			h.Lg.Warn("error sending value to host. Reconnect and retry..",
-				zap.String("target", h.Name),
-				zap.Uint16("port", h.Port),
-				zap.Error(err),
-			)
-			h.CWm.Lock()
-			err = h.Conn.Close()
-			h.CWm.Unlock()
-			if err != nil {
-				// not retrying here, file descriptor may be lost
-				h.Lg.Error("error closing the connection",
-					zap.Error(err))
-			}
-
-			h.CWm.Lock()
-			h.Conn = nil
-			h.CWm.Unlock()
+		case <-ticker.C:
+			h.Flush(time.Second * time.Duration(h.TCPOutBufFlushPeriodSec))
 		}
+	}
+}
+
+// reconnect makes sure the host stays connected
+func (h *Host) reconnectIfNecessary() {
+	for reconnectWait := uint32(0); h.Conn == nil; {
+		time.Sleep(time.Duration(reconnectWait) * time.Millisecond)
+		if reconnectWait < h.MaxReconnectPeriodMs {
+			reconnectWait = reconnectWait*2 + h.ReconnectPeriodDeltaMs
+		}
+		if reconnectWait >= h.MaxReconnectPeriodMs {
+			reconnectWait = h.MaxReconnectPeriodMs
+		}
+
+		h.Connect()
 	}
 }
 
 // Write does the remote write, i.e. sends the data
 func (h *Host) Write(b []byte) (nn int, err error) {
-	h.CWm.Lock()
-	defer h.CWm.Unlock()
 	return h.W.Write(b)
 }
 
 // Flush immediately flushes the buffer and performs a write
 func (h *Host) Flush(d time.Duration) {
-	t := time.NewTicker(d)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-h.stop:
-			return
-		case <-t.C:
-			h.CWm.Lock()
-			if h.W != nil {
-				if h.W.Buffered() != 0 {
-					err := h.W.Flush()
-					if err != nil {
-						h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
-						// if flushing fails, the connection has to be re-established
-						h.Conn = nil
-						h.W = nil
-					}
-				}
+	if h.W != nil {
+		if h.W.Buffered() != 0 {
+			err := h.W.Flush()
+			if err != nil {
+				h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
+				// if flushing fails, the connection has to be re-established
+				h.Conn = nil
+				h.W = nil
 			}
-			h.CWm.Unlock()
 		}
 	}
 }
@@ -183,8 +199,6 @@ func (h *Host) Flush(d time.Duration) {
 func (h *Host) Connect() {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", h.Name, h.Port),
 		time.Duration(h.ConnTimeoutSec)*time.Second)
-	h.CWm.Lock()
-	defer h.CWm.Unlock()
 
 	if err != nil {
 		h.Lg.Warn("connection to host failed",

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -85,6 +85,7 @@ type OptionalTicker struct {
 	t *time.Ticker
 }
 
+// NewOptionalTicker makes a new ticker that only runs if duration supplied is non-zero
 func NewOptionalTicker(d time.Duration) *OptionalTicker {
 	var ticker OptionalTicker
 	if d != 0 {
@@ -95,6 +96,7 @@ func NewOptionalTicker(d time.Duration) *OptionalTicker {
 	return &ticker
 }
 
+// Stop halts the ticker if it was ever started
 func (t *OptionalTicker) Stop() {
 	if t != nil {
 		t.Stop()

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -158,13 +158,13 @@ func (h *Host) Flush(d time.Duration) {
 		case <-t.C:
 			h.Wm.Lock()
 			if h.W != nil {
-				h.Lg.Info(fmt.Sprintf("buffered %d", h.W.Buffered()))
 				if h.W.Buffered() != 0 {
 					err := h.W.Flush()
 					if err != nil {
 						h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
 						// if flushing fails, the connection has to be re-established
-						h.Connect()
+						h.Conn = nil
+						h.W = nil
 					}
 				}
 			}

--- a/vendor/github.com/prometheus/procfs/go.mod
+++ b/vendor/github.com/prometheus/procfs/go.mod
@@ -1,3 +1,5 @@
 module github.com/prometheus/procfs
 
 require golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
+
+go 1.13


### PR DESCRIPTION
The buffer is not flushed not when there is nothing in it.
The flushing errors lead to re-connect.
Re-connect is fixed with nulling if the writer.