### PR TITLE
fix infinite recursion:

### DIFF
--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -103,9 +103,9 @@ func NewOptionalTicker(d time.Duration) *OptionalTicker {
 }
 
 // Stop halts the ticker if it was ever started
-func (t *OptionalTicker) Stop() {
-	if t != nil {
-		t.Stop()
+func (ticker *OptionalTicker) Stop() {
+	if ticker.t != nil {
+		ticker.t.Stop()
 	}
 }
 


### PR DESCRIPTION
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
runtime stack:
runtime.throw(0x94e0ec, 0xe)
github.com/bookingcom/nanotube/pkg/target.(*OptionalTicker).Stop(0xc0a7fffd98)
nanotube/pkg/target/host.go:107 +0x41 fp=0xc088000378 sp=0xc088000370 pc=0x82a981
..