### PR TITLE
clusters_tests: lower connection timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 
 .PHONY: test
 test:
-	go test -cover -race ./...
+	go test -cover -race -v ./...
 
 .PHONY: lint
 lint:

--- a/pkg/target/clusters_test.go
+++ b/pkg/target/clusters_test.go
@@ -24,6 +24,7 @@ func TestClustersWithNoAvailableHosts(t *testing.T) {
 			port = 456`
 
 	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
 	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
 
 	ms := metrics.New(&cfg)
@@ -31,6 +32,7 @@ func TestClustersWithNoAvailableHosts(t *testing.T) {
 	logger, _ := zap.NewProductionConfig().Build()
 
 	clusters, _ := NewClusters(cfg, cls, logger, ms)
+
 	for _, cluster := range clusters {
 		if len(cluster.AvailableHosts) != 0 {
 			t.Fatalf("expected 0 available hosts")
@@ -51,6 +53,7 @@ func TestClustersWithAllAvailableHosts(t *testing.T) {
 			port = 456`
 
 	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
 	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
 
 	ms := metrics.New(&cfg)
@@ -94,6 +97,7 @@ func TestClustersWithFlappingHosts(t *testing.T) {
 			port = 456`
 
 	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
 	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
 
 	ms := metrics.New(&cfg)
@@ -155,6 +159,7 @@ func TestRemoveAvailableHosts(t *testing.T) {
 			port = 456`
 
 	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
 	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
 
 	ms := metrics.New(&cfg)

--- a/pkg/target/clusters_test.go
+++ b/pkg/target/clusters_test.go
@@ -17,10 +17,10 @@ func TestClustersWithNoAvailableHosts(t *testing.T) {
 		name = "aaa"
 		type = "lb"
 			[[cluster.hosts]]
-			name = "host1"
+			name = "192.0.2.1"
 			port = 123
 			[[cluster.hosts]]
-			name = "host2"
+			name = "192.0.2.2"
 			port = 456`
 
 	cfg := conf.MakeDefault()
@@ -46,10 +46,10 @@ func TestClustersWithAllAvailableHosts(t *testing.T) {
 		name = "aaa"
 		type = "lb"
 			[[cluster.hosts]]
-			name = "host1"
+			name = "192.0.2.1"
 			port = 123
 			[[cluster.hosts]]
-			name = "host2"
+			name = "192.0.2.2"
 			port = 456`
 
 	cfg := conf.MakeDefault()
@@ -90,10 +90,10 @@ func TestClustersWithFlappingHosts(t *testing.T) {
 		name = "aaa"
 		type = "lb"
 			[[cluster.hosts]]
-			name = "host1"
+			name = "192.0.2.1"
 			port = 123
 			[[cluster.hosts]]
-			name = "host2"
+			name = "192.0.2.2"
 			port = 456`
 
 	cfg := conf.MakeDefault()
@@ -114,7 +114,7 @@ func TestClustersWithFlappingHosts(t *testing.T) {
 	var host *Host
 	cluster := clusters["aaa"]
 	for _, h := range cluster.Hosts {
-		if h.Name == "host1" {
+		if h.Name == "192.0.2.1" {
 			host = h
 		}
 	}
@@ -140,22 +140,22 @@ func TestRemoveAvailableHosts(t *testing.T) {
 		name = "aaa"
 		type = "lb"
 			[[cluster.hosts]]
-			name = "host1"
+			name = "192.0.2.1"
 			port = 123
 			[[cluster.hosts]]
-			name = "host2"
+			name = "192.0.2.2"
 			port = 456
 			[[cluster.hosts]]
-			name = "host3"
+			name = "192.0.2.3"
 			port = 456
 			[[cluster.hosts]]
-			name = "host4"
+			name = "192.0.2.4"
 			port = 456
 			[[cluster.hosts]]
-			name = "host5"
+			name = "192.0.2.5"
 			port = 456
 			[[cluster.hosts]]
-			name = "host6"
+			name = "192.0.2.6"
 			port = 456`
 
 	cfg := conf.MakeDefault()


### PR DESCRIPTION
Host in the test are invalid anyway. And NewClusters time out for that
period of time trying to connect to them.
I'm lowering the timeout so we don't have this test run for 1 minute.

I'm using addresses from the 192.0.2.0/24 class for tests instead of
host1, host2, etc.

Reason is that those addresses are reserved for 'documentation':
https://tools.ietf.org/html/rfc5737

host1, host2 might resolve(or not) depending on where we are running the
tests