### PR TITLE
Support tags with a minimal change

### DIFF
--- a/pkg/rec/rec.go
+++ b/pkg/rec/rec.go
@@ -73,20 +73,12 @@ func ParseRec(s string, normalize bool, shouldLog bool, nowF func() time.Time, l
 func (r *Rec) Serialize() *string {
 	// TODO (grzkv): serialization can be avoided in case there is no normalization
 
-	var b strings.Builder
-
-	// <r.Path> <r.RawVal> <r.RawTime>\n
-	l := 3 // two spaces, one newline
-	l += len(r.Path) + len(r.RawVal) + len(r.RawTime)
-	b.Grow(l)
-
-	b.WriteString(r.Path)
-	b.WriteByte(' ')
-	b.WriteString(r.RawVal)
-	b.WriteByte(' ')
-	b.WriteString(r.RawTime)
-	b.WriteByte('\n')
-	s := b.String()
+	// out of printf, strings.Builder (with pre-grow) and simply
+	// concat of strings, the latter turns out to be the fastest.
+	// If you change anything in the next line, benchmark:  You
+	// may cause a switch from a fast path in the Go runtime to
+	// a slow path and strings.Builder might be faster then.
+	s := r.Path + " " + r.RawVal + " " + r.RawTime + "\n"
 
 	return &s
 }

--- a/pkg/rec/rec.go
+++ b/pkg/rec/rec.go
@@ -73,8 +73,13 @@ func ParseRec(s string, normalize bool, shouldLog bool, nowF func() time.Time, l
 func (r *Rec) Serialize() *string {
 	// TODO (grzkv): serialization can be avoided in case there is no normalization
 
-	// <r.Path> <r.RawVal> <r.RawTime>\n
 	var b strings.Builder
+
+	// <r.Path> <r.RawVal> <r.RawTime>\n
+	l := 3 // two spaces, one newline
+	l += len(r.Path) + len(r.RawVal) + len(r.RawTime)
+	b.Grow(l)
+
 	b.WriteString(r.Path)
 	b.WriteByte(' ')
 	b.WriteString(r.RawVal)

--- a/pkg/rec/rec.go
+++ b/pkg/rec/rec.go
@@ -72,8 +72,17 @@ func ParseRec(s string, normalize bool, shouldLog bool, nowF func() time.Time, l
 // Serialize makes record into a string ready to be sent via TCP w/ line protocol.
 func (r *Rec) Serialize() *string {
 	// TODO (grzkv): serialization can be avoided in case there is no normalization
-	// TODO (grzkv): this may not be the fastest way to concatenate
-	s := fmt.Sprintf("%s %s %s\n", r.Path, r.RawVal, r.RawTime)
+
+	// <r.Path> <r.RawVal> <r.RawTime>\n
+	var b strings.Builder
+	b.WriteString(r.Path)
+	b.WriteByte(' ')
+	b.WriteString(r.RawVal)
+	b.WriteByte(' ')
+	b.WriteString(r.RawTime)
+	b.WriteByte('\n')
+	s := b.String()
+
 	return &s
 }
 

--- a/pkg/rec/rec_test.go
+++ b/pkg/rec/rec_test.go
@@ -218,7 +218,8 @@ func TestNormalization(t *testing.T) {
 	}
 }
 
-func TestSerialization(t *testing.T) {
+func TestSerialization(t *testing.T) { testSerialization(t) }
+func testSerialization(t testing.TB) {
 	tt := []struct {
 		in  Rec
 		out string
@@ -249,5 +250,12 @@ func TestSerialization(t *testing.T) {
 		if *test.in.Serialize() != test.out {
 			t.Errorf("expected serialization output %s, got %s for record %+v", test.out, *test.in.Serialize(), test.in)
 		}
+	}
+}
+
+func BenchmarkSerialization(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// This also benches string comparison in the test, but let's keep it simple.
+		testSerialization(b)
 	}
 }


### PR DESCRIPTION

* Add a simple support for tags for line protocol
* Drops string pointer from normalizePath
* Cherry-pick changes from https://github.com/bookingcom/nanotube/pull/29 by @jwkohnen (Couldn't rebase my works on jwkohnen's change due to conflicts)

(I do agree with @dgryski on using byte array directly returned from net.Conn, but that's bigger change.)

Adding this simple tag support for exploring a new solution of supporting high cardinality metrics in go-carbon.