### PR TITLE
Add 'listenTCP' and 'ListenUDP' options

### DIFF
--- a/cmd/nanotube/listen.go
+++ b/cmd/nanotube/listen.go
@@ -34,7 +34,7 @@ func parseListenOption(listenOption string) (net.IP, int, error) {
 	}
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
-		return ip, port, errors.New("Could not parse IP")
+		return ip, port, errors.New("could not parse IP")
 	}
 	return ip, port, nil
 }

--- a/cmd/nanotube/listen.go
+++ b/cmd/nanotube/listen.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bufio"
-	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,12 +15,43 @@ import (
 	"go.uber.org/zap"
 )
 
+// parse "ip:port" string that is used for ListenTCP and ListenUDP config options
+func parseListenOption(listenOption string) (net.IP, int, error) {
+	ipStr, portStr, err := net.SplitHostPort(listenOption)
+	if err != nil {
+		return nil, 0, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, port, err
+	}
+	if port < 0 || port > 65535 {
+		return nil, port, errors.New("invalid port value")
+	}
+	// ":2003" will listen on all IPs
+	if ipStr == "" {
+		return nil, port, nil
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return ip, port, errors.New("Could not parse IP")
+	}
+	return ip, port, nil
+}
+
 // Listen listens for incoming metric data
 func Listen(cfg *conf.Main, stop <-chan struct{}, lg *zap.Logger, ms *metrics.Prom) (chan string, error) {
 	queue := make(chan string, cfg.MainQueueSize)
 
-	if cfg.EnableTCP {
-		l, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.ListeningPort))
+	if cfg.ListenTCP != "" {
+		ip, port, err := parseListenOption(cfg.ListenTCP)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing ListenTCP option")
+		}
+		l, err := net.ListenTCP("tcp", &net.TCPAddr{
+			IP:   ip,
+			Port: port,
+		})
 		if err != nil {
 			return nil, errors.Wrap(err,
 				"error while opening TCP port for listening")
@@ -28,11 +59,15 @@ func Listen(cfg *conf.Main, stop <-chan struct{}, lg *zap.Logger, ms *metrics.Pr
 		go acceptAndListenTCP(l, queue, stop, cfg, ms, lg)
 	}
 
-	if cfg.EnableUDP {
+	if cfg.ListenUDP != "" {
+		ip, port, err := parseListenOption(cfg.ListenUDP)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing ListenUDP option")
+		}
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{
-			IP:   nil,
-			Port: int(cfg.ListeningPort),
-			Zone: ""})
+			IP:   ip,
+			Port: port,
+		})
 		if err != nil {
 			lg.Error("error while opening UDP port for listening", zap.Error(err))
 			return nil, errors.Wrap(err,

--- a/cmd/nanotube/testdata/config.toml
+++ b/cmd/nanotube/testdata/config.toml
@@ -1,8 +1,9 @@
-# The port to listen to for incoming connections.
-ListeningPort = 12123
 # The default target port on receiver hosts. Can be overridden in the clusters setup.
 TargetPort = 12003
-EnableUDP = true
+
+# Addresses to listen on
+ListenTCP = ":12123"
+ListenUDP = ":12123"
 
 # The size on main queue between listen and routing. Refer to docs for details.
 MainQueueSize = 100

--- a/config/config.toml
+++ b/config/config.toml
@@ -2,15 +2,14 @@
 
 # WARNING: This is a sample config. You most likely need to tweak it for your use case.
 
-# The port to listen to for incoming connections.
-ListeningPort = 2003
 # The default target port on receiver hosts. Can be overridden in the clusters setup.
 TargetPort = 2004
 
-# Setting this to true will enable TCP listening on ListeningPort
-EnableTCP = true
-# Setting this to true will enable UDP listening on ListeningPort
-EnableUDP = false
+# Setting this to ip:port will enable TCP listening on specified address. Empty string to disable TCP listening.
+ListenTCP = ":2003"
+# Setting this to ip:port will enable UDP listening on specified address. Empty string to disable UDP listening
+ListenUDP = ""
+
 # Size of OS buffer for reading from UDP connction. Buffer not set if zero.
 UDPOSBufferSize = 0
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -5,9 +5,13 @@
 # The default target port on receiver hosts. Can be overridden in the clusters setup.
 TargetPort = 2004
 
-# Setting this to ip:port will enable TCP listening on specified address. Empty string to disable TCP listening.
+# Setting this to ip:port will enable TCP listening on specified address.
+# 	Empty string to disable TCP listening.
+#		Empty ip to listen on all addresses.
 ListenTCP = ":2003"
-# Setting this to ip:port will enable UDP listening on specified address. Empty string to disable UDP listening
+# Setting this to ip:port will enable UDP listening on specified address.
+#		Empty string to disable UDP listening.
+#		Empty ip to listen on all addresses.
 ListenUDP = ""
 
 # Size of OS buffer for reading from UDP connction. Buffer not set if zero.

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -9,11 +9,12 @@ import (
 
 // Main is the main and generic nanotube config.
 type Main struct {
-	ListeningPort uint32
-	TargetPort    uint16
+	TargetPort uint16
 
-	EnableTCP bool
-	EnableUDP bool
+	// empty string not to listen
+	ListenTCP string
+	ListenUDP string
+
 	// 0 does not set buffer size
 	UDPOSBufferSize uint32
 
@@ -55,19 +56,19 @@ func ReadMain(r io.Reader) (Main, error) {
 	if cfg.PprofPort == cfg.PromPort {
 		return cfg, errors.New("PromPort and PprofPort can't have the same value")
 	}
-	if !cfg.EnableTCP && !cfg.EnableUDP {
+	if cfg.ListenTCP == "" && cfg.ListenUDP == "" {
 		return cfg, errors.New("we don't listen neither on TCP nor on UDP")
 	}
+
 	return cfg, nil
 }
 
 // MakeDefault creates configuration with default values.
 func MakeDefault() Main {
 	return Main{
-		ListeningPort: 2003,
-		TargetPort:    2004,
+		TargetPort: 2004,
 
-		EnableTCP: true,
+		ListenTCP: ":2003",
 
 		MainQueueSize:  1000,
 		HostQueueSize:  1000,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestConfSimple(t *testing.T) {
 	conf := `
-	ListeningPort = 2003
-	EnableUDP = true
-	EnableTCP = false
+	ListenUDP = "1.2.3.4:2003"
+	ListenTCP = ":2003"
 	TargetPort = 2008
 
 	SendTimeoutSec = 7
@@ -26,11 +25,10 @@ func TestConfSimple(t *testing.T) {
 	TCPOutBufFlushPeriodSec = 3`
 
 	expected := Main{
-		ListeningPort: 2003,
-		TargetPort:    2008,
+		TargetPort: 2008,
 
-		EnableTCP: false,
-		EnableUDP: true,
+		ListenTCP: ":2003",
+		ListenUDP: "1.2.3.4:2003",
 
 		MainQueueSize: 100,
 		HostQueueSize: 10,


### PR DESCRIPTION
This should close https://github.com/bookingcom/nanotube/issues/28.

Other changes related to this
 - removed ListenPort and EnableTCP, EnableUDP options. By replacing
   them with ListenUDP and ListenTCP options we can have UDP and TCP
   listening on two different ports. And we can disable each of them by
   using the empty string
 - I'm not sure if we should make those config options to be arrays or not.
   If we make the arrays, we could listen to multiple addresses in the future.
   I guess we can update them to an array when we need this.
 - Updated ListenTCP to be consistent with UDP listening.