### PR TITLE
Adds load balancing to nanotube

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -41,6 +41,14 @@ TCPOutBufSize = 4096
 # The value of zero means no flushing.
 TCPOutBufFlushPeriodSec = 2
 
+# Maximum reconnection period to target host
+MaxHostReconnectPeriodMs = 5000
+# Parameter for exponential backoffs during reconnects
+HostReconnectPeriodDeltaMs = 10
+# Threshold to indicate to cluster for host connection loss
+#Should be less than MaxHostReconnectPeriodMs
+ConnectionLossThresholdMs = 3000
+
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true
 # Turns on logging for special kinds of records. For now it's recrods with fractional timestamps.

--- a/pkg/conf/clusters.go
+++ b/pkg/conf/clusters.go
@@ -18,9 +18,9 @@ type Clusters struct {
 // fnv1a hasing following by the jump one. Every record is sent to only one host.
 const JumpCluster string = "jump"
 
-// LB cluster type distributes incoming datapoints using xxHash modulo N, where
+// LB cluster type distributes incoming datapoints using fnv modulo N, where
 // N  equal no. of available hosts
-// As such, this cluster type keeps the list of available hosts and send traffic
+// As such, this cluster type keeps the list of available hosts and sends traffic
 // only to these
 const LB string = "lb"
 

--- a/pkg/conf/clusters.go
+++ b/pkg/conf/clusters.go
@@ -18,6 +18,12 @@ type Clusters struct {
 // fnv1a hasing following by the jump one. Every record is sent to only one host.
 const JumpCluster string = "jump"
 
+// LB cluster type distributes incoming datapoints using xxHash modulo N, where
+// N  equal no. of available hosts
+// As such, this cluster type keeps the list of available hosts and send traffic
+// only to these
+const LB string = "lb"
+
 // ToallCluster broadcasts records to all hosts in the cluster.
 const ToallCluster string = "toall"
 

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -25,6 +25,10 @@ type Main struct {
 	IncomingConnIdleTimeoutSec uint32
 	SendTimeoutSec             uint32
 	OutConnTimeoutSec          uint32
+	MaxHostReconnectPeriodMs   uint32
+	HostReconnectPeriodDeltaMs uint32
+	KeepAliveSec               uint32
+	ConnectionLossThresholdMs  uint32
 	TermTimeoutSec             uint16
 	// 0 value turns off buffering
 	TCPOutBufSize int
@@ -76,6 +80,10 @@ func MakeDefault() Main {
 		IncomingConnIdleTimeoutSec: 90,
 		SendTimeoutSec:             5,
 		OutConnTimeoutSec:          5,
+		MaxHostReconnectPeriodMs:   5000,
+		HostReconnectPeriodDeltaMs: 10,
+		KeepAliveSec:               1,
+		ConnectionLossThresholdMs:  3000,
 		TermTimeoutSec:             10,
 		TCPOutBufSize:              0,
 		TCPOutBufFlushPeriodSec:    2,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -23,7 +23,11 @@ func TestConfSimple(t *testing.T) {
 	HostQueueSize = 10
 	WorkerPoolSize = 10
 	TCPOutBufSize = 11
-	TCPOutBufFlushPeriodSec = 3`
+	TCPOutBufFlushPeriodSec = 3
+	KeepAliveSec = 3
+	MaxHostReconnectPeriodMs = 777
+	HostReconnectPeriodDeltaMs = 13
+	ConnectionLossThresholdMs = 200`
 
 	expected := Main{
 		ListeningPort: 2003,
@@ -43,6 +47,10 @@ func TestConfSimple(t *testing.T) {
 		TermTimeoutSec:             11,
 		TCPOutBufSize:              11,
 		TCPOutBufFlushPeriodSec:    3,
+		KeepAliveSec:               3,
+		MaxHostReconnectPeriodMs:   777,
+		HostReconnectPeriodDeltaMs: 13,
+		ConnectionLossThresholdMs:  200,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,11 +10,12 @@ import (
 
 // Prom is the set of Prometheus metrics.
 type Prom struct {
-	InRecs         prometheus.Counter
-	OutRecs        *prometheus.CounterVec
-	ThrottledRecs  prometheus.Counter
-	BlackholedRecs prometheus.Counter
-	ErrorRecs      prometheus.Counter
+	InRecs           prometheus.Counter
+	OutRecs          *prometheus.CounterVec
+	ThrottledRecs    prometheus.Counter
+	StateChangeHosts *prometheus.CounterVec
+	BlackholedRecs   prometheus.Counter
+	ErrorRecs        prometheus.Counter
 
 	ThrottledHosts *prometheus.CounterVec
 
@@ -54,6 +55,11 @@ func New(conf *conf.Main) *Prom {
 			Namespace: "nanotube",
 			Name:      "throttled_host_records_total",
 			Help:      "Records dropped from the host queue because it's full.",
+		}, []string{"cluster", "upstream_host"}),
+		StateChangeHosts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "nanotube",
+			Name:      "state_change_hosts_total",
+			Help:      "Total availability state change for hosts",
 		}, []string{"cluster", "upstream_host"}),
 		BlackholedRecs: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "nanotube",
@@ -121,6 +127,11 @@ func Register(m *Prom) {
 	err = prometheus.Register(m.ThrottledRecs)
 	if err != nil {
 		log.Fatalf("error registering the throttled_records_counter metric: %v", err)
+	}
+
+	err = prometheus.Register(m.StateChangeHosts)
+	if err != nil {
+		log.Fatalf("error registering the state_change_hosts_total metrics: %v", err)
 	}
 
 	err = prometheus.Register(m.ThrottledHosts)

--- a/pkg/target/cluster.go
+++ b/pkg/target/cluster.go
@@ -164,11 +164,11 @@ func (cl *Cluster) addAvailableHost(host *Host) {
 }
 
 func (cl *Cluster) removeAvailableHost(host *Host) {
+	cl.Hm.Lock()
+	defer cl.Hm.Unlock()
 	for i, h := range cl.AvailableHosts {
 		if h == host {
 			host.stateChanges.Inc()
-			cl.Hm.Lock()
-			defer cl.Hm.Unlock()
 			length := len(cl.AvailableHosts)
 
 			for j := i; j < length-1; j++ {

--- a/pkg/target/cluster.go
+++ b/pkg/target/cluster.go
@@ -2,7 +2,6 @@ package target
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
@@ -131,24 +130,6 @@ func (cl *Cluster) getAvailableHosts() []*Host {
 		}
 	}
 	return availableHosts
-}
-func (cl *Cluster) getFailedHosts() []*Host {
-	cl.Hm.RLock()
-	defer cl.Hm.RUnlock()
-	availableHostsLength := len(cl.AvailableHosts)
-	var failedHosts []*Host
-	if availableHostsLength != len(cl.Hosts) {
-		availableHosts := make(map[string]struct{})
-		for _, h := range cl.AvailableHosts {
-			availableHosts[h.Name+strconv.Itoa(int(h.Port))] = struct{}{}
-		}
-		for _, h := range cl.Hosts {
-			if _, ok := availableHosts[h.Name+strconv.Itoa(int(h.Port))]; !ok {
-				failedHosts = append(failedHosts, h)
-			}
-		}
-	}
-	return failedHosts
 }
 
 func (cl *Cluster) keepAvailableHostsUpdated() {

--- a/pkg/target/clusters.go
+++ b/pkg/target/clusters.go
@@ -66,9 +66,9 @@ func NewClusters(mainCfg conf.Main, cfg conf.Clusters, lg *zap.Logger, ms *metri
 	for _, cl := range cls {
 		go cl.keepAvailableHostsUpdated()
 		if cl.Type == conf.LB {
-			go cl.addUpAgainFailedHosts(time.Duration(mainCfg.MaxHostReconnectPeriodMs) * time.Millisecond)
+			go cl.updateAvailableHostsPeriodically(time.Duration(mainCfg.MaxHostReconnectPeriodMs) * time.Millisecond)
 			for _, h := range cl.Hosts {
-				h.Connect()
+				h.Connect(1)
 			}
 		}
 	}

--- a/pkg/target/clusters.go
+++ b/pkg/target/clusters.go
@@ -3,6 +3,7 @@ package target
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
 	"github.com/bookingcom/nanotube/pkg/metrics"
@@ -40,42 +41,58 @@ func (cls Clusters) Send(finish chan struct{}) chan struct{} {
 func NewClusters(mainCfg conf.Main, cfg conf.Clusters, lg *zap.Logger, ms *metrics.Prom) (Clusters, error) {
 	// TODO (grzkv): Add duplicate defense
 	cls := make(map[string]*Cluster)
+	var err error
 	for _, cc := range cfg.Cluster {
-		cl := Cluster{
-			Name: cc.Name,
+		cl := &Cluster{
+			Name:                   cc.Name,
+			UpdateHostHealthStatus: make(chan *HostStatus),
+			Type:                   cc.Type,
 		}
 		switch cc.Type {
 		case conf.JumpCluster:
-			cl.Hosts = make([]*Host, len(cc.Hosts))
+			cl, err = getJumpCluster(cl, cc, mainCfg, lg, ms)
+		case conf.BlackholeCluster, conf.ToallCluster, conf.LB:
 			for _, h := range cc.Hosts {
-				if cl.Hosts[h.Index] != nil {
-					return cls, fmt.Errorf("duplicate index value, or index not set for a hashed cluster %s", cc.Name)
-				}
-
-				if h.Index >= len(cl.Hosts) {
-					return cls, fmt.Errorf("host %s index %d out of bounds in cluster %s (cluster size %d)", h.Name, h.Index, cl.Name, len(cl.Hosts))
-				}
-
-				cl.Hosts[h.Index] = NewHost(cc.Name, mainCfg, h, lg, ms)
-			}
-
-			for _, hst := range cl.Hosts {
-				if hst == nil {
-					return cls, fmt.Errorf("not all host indexes were set for cluster %v", cc.Name)
-				}
-			}
-		case conf.BlackholeCluster, conf.ToallCluster:
-			for _, h := range cc.Hosts {
-				cl.Hosts = append(cl.Hosts, NewHost(cc.Name, mainCfg, h, lg, ms))
+				cl.Hosts = append(cl.Hosts, NewHost(cc.Name, mainCfg, h, lg, ms, cl.UpdateHostHealthStatus))
 			}
 		default:
 			return cls, fmt.Errorf("incorrect cluster type %s for cluster %s",
 				cl.Type, cl.Name)
 		}
-		cl.Type = cc.Type
 
-		cls[cl.Name] = &cl
+		cls[cl.Name] = cl
 	}
 
-	return cls, nil
+	for _, cl := range cls {
+		go cl.keepAvailableHostsUpdated()
+		if cl.Type == conf.LB {
+			go cl.addUpAgainFailedHosts(time.Duration(mainCfg.MaxHostReconnectPeriodMs) * time.Millisecond)
+			for _, h := range cl.Hosts {
+				h.Connect()
+			}
+		}
+	}
+	return cls, err
+}
+
+func getJumpCluster(cl *Cluster, cc conf.Cluster, mainCfg conf.Main, lg *zap.Logger, ms *metrics.Prom) (*Cluster, error) {
+	cl.Hosts = make([]*Host, len(cc.Hosts))
+	for _, h := range cc.Hosts {
+		if cl.Hosts[h.Index] != nil {
+			return cl, fmt.Errorf("duplicate index value, or index not set for a hashed cluster %s", cc.Name)
+		}
+
+		if h.Index >= len(cl.Hosts) {
+			return cl, fmt.Errorf("host %s index %d out of bounds in cluster %s (cluster size %d)", h.Name, h.Index, cl.Name, len(cl.Hosts))
+		}
+
+		cl.Hosts[h.Index] = NewHost(cc.Name, mainCfg, h, lg, ms, cl.UpdateHostHealthStatus)
+	}
+
+	for _, hst := range cl.Hosts {
+		if hst == nil {
+			return cl, fmt.Errorf("not all host indexes were set for cluster %v", cc.Name)
+		}
+	}
+	return cl, nil
 }

--- a/pkg/target/clusters_test.go
+++ b/pkg/target/clusters_test.go
@@ -1,0 +1,215 @@
+package target
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bookingcom/nanotube/pkg/conf"
+	"github.com/bookingcom/nanotube/pkg/metrics"
+	"go.uber.org/zap"
+)
+
+func TestClustersWithNoAvailableHosts(t *testing.T) {
+	clsConfig :=
+		`[[cluster]]
+		name = "aaa"
+		type = "lb"
+			[[cluster.hosts]]
+			name = "192.0.2.1"
+			port = 123
+			[[cluster.hosts]]
+			name = "192.0.2.2"
+			port = 456`
+
+	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
+	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
+
+	ms := metrics.New(&cfg)
+
+	logger, _ := zap.NewProductionConfig().Build()
+
+	clusters, _ := NewClusters(cfg, cls, logger, ms)
+
+	for _, cluster := range clusters {
+		if len(cluster.AvailableHosts) != 0 {
+			t.Fatalf("expected 0 available hosts")
+		}
+	}
+}
+
+func TestClustersWithAllAvailableHosts(t *testing.T) {
+	clsConfig :=
+		`[[cluster]]
+		name = "aaa"
+		type = "lb"
+			[[cluster.hosts]]
+			name = "192.0.2.1"
+			port = 123
+			[[cluster.hosts]]
+			name = "192.0.2.2"
+			port = 456`
+
+	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
+	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
+
+	ms := metrics.New(&cfg)
+
+	logger, _ := zap.NewProductionConfig().Build()
+
+	clusters, _ := NewClusters(cfg, cls, logger, ms)
+	for _, cluster := range clusters {
+		if len(cluster.AvailableHosts) != 0 {
+			t.Fatalf("expected 0 available hosts")
+		}
+	}
+
+	sigChs := make([]chan struct{}, 0)
+	for _, cluster := range clusters {
+		for _, h := range cluster.Hosts {
+			ch := make(chan struct{})
+			sigChs = append(sigChs, ch)
+			cluster.UpdateHostHealthStatus <- &HostStatus{h, true, ch}
+		}
+		for _, sigCh := range sigChs {
+			<-sigCh
+		}
+		if len(cluster.AvailableHosts) != 2 {
+			t.Fatalf("expected 2 available hosts, found %d", len(cluster.AvailableHosts))
+		}
+	}
+
+}
+
+func TestClustersWithFlappingHosts(t *testing.T) {
+	clsConfig :=
+		`[[cluster]]
+		name = "aaa"
+		type = "lb"
+			[[cluster.hosts]]
+			name = "192.0.2.1"
+			port = 123
+			[[cluster.hosts]]
+			name = "192.0.2.2"
+			port = 456`
+
+	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
+	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
+
+	ms := metrics.New(&cfg)
+
+	logger, _ := zap.NewProductionConfig().Build()
+
+	clusters, _ := NewClusters(cfg, cls, logger, ms)
+	for _, cluster := range clusters {
+		if len(cluster.AvailableHosts) != 0 {
+			t.Fatalf("expected 0 available hosts")
+		}
+	}
+
+	var host *Host
+	cluster := clusters["aaa"]
+	for _, h := range cluster.Hosts {
+		if h.Name == "192.0.2.1" {
+			host = h
+		}
+	}
+
+	ch := make(chan struct{})
+	cluster.UpdateHostHealthStatus <- &HostStatus{host, true, ch}
+	<-ch
+	if len(cluster.AvailableHosts) != 1 {
+		t.Fatalf("expected 1 available hosts, found %d", len(cluster.AvailableHosts))
+	}
+
+	ch = make(chan struct{})
+	cluster.UpdateHostHealthStatus <- &HostStatus{host, false, ch}
+	<-ch
+	if len(cluster.AvailableHosts) != 0 {
+		t.Fatalf("expected 0 available hosts, found %d", len(cluster.AvailableHosts))
+	}
+}
+
+func TestRemoveAvailableHosts(t *testing.T) {
+	clsConfig :=
+		`[[cluster]]
+		name = "aaa"
+		type = "lb"
+			[[cluster.hosts]]
+			name = "192.0.2.1"
+			port = 123
+			[[cluster.hosts]]
+			name = "192.0.2.2"
+			port = 456
+			[[cluster.hosts]]
+			name = "192.0.2.3"
+			port = 456
+			[[cluster.hosts]]
+			name = "192.0.2.4"
+			port = 456
+			[[cluster.hosts]]
+			name = "192.0.2.5"
+			port = 456
+			[[cluster.hosts]]
+			name = "192.0.2.6"
+			port = 456`
+
+	cfg := conf.MakeDefault()
+	cfg.OutConnTimeoutSec = 1
+	cls, _ := conf.ReadClustersConfig(strings.NewReader(clsConfig))
+
+	ms := metrics.New(&cfg)
+
+	logger, _ := zap.NewProductionConfig().Build()
+
+	clusters, _ := NewClusters(cfg, cls, logger, ms)
+	for _, cluster := range clusters {
+		if len(cluster.AvailableHosts) != 0 {
+			t.Fatalf("expected 0 available hosts")
+		}
+	}
+
+	cluster := clusters["aaa"]
+	hosts := cluster.Hosts
+	shuffledHosts := shuffle(hosts)
+
+	n := len(hosts)
+	sigChs := make([]chan struct{}, 0)
+	for _, cluster := range clusters {
+		for _, h := range cluster.Hosts {
+			ch := make(chan struct{})
+			sigChs = append(sigChs, ch)
+			cluster.UpdateHostHealthStatus <- &HostStatus{h, true, ch}
+		}
+		for _, sigCh := range sigChs {
+			<-sigCh
+		}
+		if len(cluster.AvailableHosts) != n {
+			t.Fatalf("expected 6 available hosts, found %d", len(cluster.AvailableHosts))
+		}
+	}
+
+	for _, host := range shuffledHosts {
+		ch := make(chan struct{})
+		cluster.UpdateHostHealthStatus <- &HostStatus{host, false, ch}
+		<-ch
+		n--
+		if len(cluster.AvailableHosts) != n {
+			t.Fatalf("expected %d available hosts", n)
+		}
+	}
+}
+
+func shuffle(hosts []*Host) []*Host {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	shuffledHosts := make([]*Host, len(hosts))
+	perm := r.Perm(len(hosts))
+	for i, randIndex := range perm {
+		shuffledHosts[i] = hosts[randIndex]
+	}
+	return shuffledHosts
+}

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -220,7 +220,7 @@ func (h *Host) getConnectionToHost() (net.Conn, error) {
 		Timeout:   time.Duration(h.ConnTimeoutSec) * time.Second,
 		KeepAlive: time.Duration(h.KeepAliveSec) * time.Second,
 	}
-	conn, err := dialer.Dial("tcp", net.JoinHostPort(h.Name, h.Port))
+	conn, err := dialer.Dial("tcp", net.JoinHostPort(h.Name, fmt.Sprint(h.Port)))
 	return conn, err
 }
 

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -220,7 +220,7 @@ func (h *Host) getConnectionToHost() (net.Conn, error) {
 		Timeout:   time.Duration(h.ConnTimeoutSec) * time.Second,
 		KeepAlive: time.Duration(h.KeepAliveSec) * time.Second,
 	}
-	conn, err := dialer.Dial("tcp", fmt.Sprintf("%s:%d", h.Name, h.Port))
+	conn, err := dialer.Dial("tcp", net.JoinHostPort(h.Name, h.Port))
 	return conn, err
 }
 

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -222,7 +222,6 @@ func (h *Host) getConnectionToHost() (net.Conn, error) {
 
 func (h *Host) checkUpdateHostStatus() {
 	conn, _ := h.getConnectionToHost()
-	fmt.Println(conn)
 	if conn != nil {
 		_ = conn.Close()
 		h.updateHostHealthStatus <- &HostStatus{Host: h, Status: true, sigCh: make(chan struct{})}

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -227,8 +227,8 @@ func (h *Host) getConnectionToHost() (net.Conn, error) {
 func (h *Host) checkUpdateHostStatus(hostStatus chan HostStatus) {
 	conn, _ := h.getConnectionToHost()
 	if conn != nil {
-		defer conn.Close()
 		hostStatus <- HostStatus{Host: h, Status: true, sigCh: make(chan struct{})}
+		_ = conn.Close()
 	} else {
 		hostStatus <- HostStatus{Host: h, Status: false, sigCh: make(chan struct{})}
 	}

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -27,20 +27,34 @@ type Host struct {
 	Wm   sync.Mutex
 	stop chan int
 
-	Lg                      *zap.Logger
-	Ms                      *metrics.Prom
-	SendTimeoutSec          uint32
-	ConnTimeoutSec          uint32
-	TCPOutBufFlushPeriodSec uint32
+	updateHostHealthStatus chan *HostStatus
+
+	Lg                        *zap.Logger
+	Ms                        *metrics.Prom
+	SendTimeoutSec            uint32
+	ConnTimeoutSec            uint32
+	KeepAliveSec              uint32
+	MaxReconnectPeriodMs      uint32
+	ReconnectPeriodDeltaMs    uint32
+	ConnectionLossThresholdMs uint32
+	TCPOutBufFlushPeriodSec   uint32
 
 	outRecs            prometheus.Counter
 	throttled          prometheus.Counter
+	stateChanges       prometheus.Counter
 	processingDuration prometheus.Histogram
 	bufSize            int
 }
 
+// HostStatus is used to signal connection status by Host to cluster
+type HostStatus struct {
+	Host   *Host
+	Status bool
+	sigCh  chan struct{}
+}
+
 //NewHost build new host object from config
-func NewHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.Logger, ms *metrics.Prom) *Host {
+func NewHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.Logger, ms *metrics.Prom, updateHostHealthStatus chan *HostStatus) *Host {
 	targetPort := mainCfg.TargetPort
 	if hostCfg.Port != 0 {
 		targetPort = hostCfg.Port
@@ -51,19 +65,25 @@ func NewHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.L
 		"upstream_host": hostCfg.Name,
 	}
 	return &Host{
-		Name: hostCfg.Name,
-		Port: targetPort,
-		Ch:   make(chan *rec.Rec, mainCfg.HostQueueSize),
-		Lg:   lg,
-		stop: make(chan int),
+		Name:                   hostCfg.Name,
+		Port:                   targetPort,
+		Ch:                     make(chan *rec.Rec, mainCfg.HostQueueSize),
+		Lg:                     lg,
+		stop:                   make(chan int),
+		updateHostHealthStatus: updateHostHealthStatus,
 
-		SendTimeoutSec:          mainCfg.SendTimeoutSec,
-		ConnTimeoutSec:          mainCfg.OutConnTimeoutSec,
-		TCPOutBufFlushPeriodSec: mainCfg.TCPOutBufFlushPeriodSec,
-		outRecs:                 ms.OutRecs.With(promLabels),
-		throttled:               ms.ThrottledHosts.With(promLabels),
-		processingDuration:      ms.ProcessingDuration,
-		bufSize:                 mainCfg.TCPOutBufSize,
+		SendTimeoutSec:            mainCfg.SendTimeoutSec,
+		ConnTimeoutSec:            mainCfg.OutConnTimeoutSec,
+		KeepAliveSec:              mainCfg.KeepAliveSec,
+		MaxReconnectPeriodMs:      mainCfg.MaxHostReconnectPeriodMs,
+		ReconnectPeriodDeltaMs:    mainCfg.MaxHostReconnectPeriodMs,
+		ConnectionLossThresholdMs: mainCfg.ConnectionLossThresholdMs,
+		TCPOutBufFlushPeriodSec:   mainCfg.TCPOutBufFlushPeriodSec,
+		outRecs:                   ms.OutRecs.With(promLabels),
+		throttled:                 ms.ThrottledHosts.With(promLabels),
+		processingDuration:        ms.ProcessingDuration,
+		stateChanges:              ms.StateChangeHosts.With(promLabels),
+		bufSize:                   mainCfg.TCPOutBufSize,
 	}
 }
 
@@ -92,15 +112,18 @@ func (h *Host) Stream(wg *sync.WaitGroup) {
 	for r := range h.Ch {
 		// retry until successful
 		for {
-			const maxReconnectPeriodMs = 5000
-			const reconnectDeltaMs = 10
-			for reconnectWait := 0; h.Conn == nil; {
+			for reconnectWait := uint32(0); h.Conn == nil; {
+				hostConnectionStatus := true
 				time.Sleep(time.Duration(reconnectWait) * time.Millisecond)
-				if reconnectWait < maxReconnectPeriodMs {
-					reconnectWait = reconnectWait*2 + reconnectDeltaMs
+				if reconnectWait > h.ConnectionLossThresholdMs && !hostConnectionStatus {
+					hostConnectionStatus = false
+					h.updateHostHealthStatus <- &HostStatus{Host: h, Status: hostConnectionStatus, sigCh: make(chan struct{})}
 				}
-				if reconnectWait >= maxReconnectPeriodMs {
-					reconnectWait = maxReconnectPeriodMs
+				if reconnectWait < h.MaxReconnectPeriodMs {
+					reconnectWait = reconnectWait*2 + h.ReconnectPeriodDeltaMs
+				}
+				if reconnectWait >= h.MaxReconnectPeriodMs {
+					reconnectWait = h.MaxReconnectPeriodMs
 				}
 
 				h.Connect()
@@ -170,8 +193,7 @@ func (h *Host) Flush(d time.Duration) {
 
 // Connect connects to target host via TCP. If unsuccessful, sets conn to nil.
 func (h *Host) Connect() {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", h.Name, h.Port),
-		time.Duration(h.ConnTimeoutSec)*time.Second)
+	conn, err := h.getConnectionToHost()
 	if err != nil {
 		h.Lg.Warn("connection to host failed",
 			zap.String("host", h.Name),
@@ -182,8 +204,27 @@ func (h *Host) Connect() {
 	}
 
 	h.Conn = conn
+	h.updateHostHealthStatus <- &HostStatus{Host: h, Status: true, sigCh: make(chan struct{})}
 
 	h.Wm.Lock()
 	defer h.Wm.Unlock()
 	h.W = bufio.NewWriterSize(conn, h.bufSize)
+}
+
+func (h *Host) getConnectionToHost() (net.Conn, error) {
+	dialer := net.Dialer{
+		Timeout:   time.Duration(h.ConnTimeoutSec) * time.Second,
+		KeepAlive: time.Duration(h.KeepAliveSec) * time.Second,
+	}
+	conn, err := dialer.Dial("tcp", fmt.Sprintf("%s:%d", h.Name, h.Port))
+	return conn, err
+}
+
+func (h *Host) checkUpdateHostStatus() {
+	conn, _ := h.getConnectionToHost()
+	fmt.Println(conn)
+	if conn != nil {
+		_ = conn.Close()
+		h.updateHostHealthStatus <- &HostStatus{Host: h, Status: true, sigCh: make(chan struct{})}
+	}
 }


### PR DESCRIPTION
Clusters check if new connections can be made to failed hosts. Also, the host connection
logic reconnection logic remains the same. The hosts now only
signal to the cluster to update host  status if it cannot connect
after a certain threshold.