### PR TITLE
Buffer flush fix

### DIFF
--- a/pkg/target/cluster.go
+++ b/pkg/target/cluster.go
@@ -101,7 +101,7 @@ func (cl *Cluster) updateAvailableHostsPeriodically(d time.Duration) {
 	t := time.NewTicker(d)
 	defer t.Stop()
 
-	for range t.C {
+	for ; true; <-t.C {
 		availableHosts := cl.getAvailableHosts()
 		cl.updateAvailableHosts(availableHosts)
 	}

--- a/pkg/target/clusters.go
+++ b/pkg/target/clusters.go
@@ -67,9 +67,6 @@ func NewClusters(mainCfg conf.Main, cfg conf.Clusters, lg *zap.Logger, ms *metri
 		go cl.keepAvailableHostsUpdated()
 		if cl.Type == conf.LB {
 			go cl.updateAvailableHostsPeriodically(time.Duration(mainCfg.MaxHostReconnectPeriodMs) * time.Millisecond)
-			for _, h := range cl.Hosts {
-				h.Connect(1)
-			}
 		}
 	}
 	return cls, err

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -117,7 +117,7 @@ func (h *Host) tryToSend(r *rec.Rec) {
 		err := h.Conn.SetWriteDeadline(time.Now().Add(
 			time.Duration(h.SendTimeoutSec) * time.Second))
 		if err != nil {
-			h.Lg.Warn("error setting write deadline. Renewing the connection.", zap.Error(err))
+			h.Lg.Warn("error setting write deadline", zap.Error(err))
 		}
 
 		// this may loose one record on disconnect

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -155,8 +155,7 @@ func (h *Host) Flush(d time.Duration) {
 			return
 		case <-t.C:
 			h.CWm.Lock()
-			if h.Conn != nil && h.W != nil {
-				if h.W.Buffered() != 0 {
+			if h.Conn != nil && h.W != nil && h.W.Buffered() != 0 {
 					err := h.W.Flush()
 					if err != nil {
 						h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -156,12 +156,11 @@ func (h *Host) Flush(d time.Duration) {
 		case <-t.C:
 			h.CWm.Lock()
 			if h.Conn != nil && h.W != nil && h.W.Buffered() != 0 {
-					err := h.W.Flush()
-					if err != nil {
-						h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
-						h.Conn = nil
-						h.W = nil
-					}
+				err := h.W.Flush()
+				if err != nil {
+					h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
+					h.Conn = nil
+					h.W = nil
 				}
 			}
 			h.CWm.Unlock()


### PR DESCRIPTION
## What issue is this change attempting to solve?
* Too many errors on buffer flush fail after disconnect
* Races not protected by a mutex

## How does this change solve the problem? Why is this the best approach?
* correct mutex use
* reconnect after connection drop on buffer flush fail

## How can we be sure this works as expected?
* tested locally and on a single production instance