### PR TITLE
Short metrics option

### DIFF
--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -150,7 +150,7 @@ func loadBuildRegister(cfgPath, clPath, rulesPath, rewritesPath string,
 	}
 
 	ms := metrics.New(&cfg)
-	metrics.Register(ms)
+	metrics.Register(ms, &cfg)
 	ms.Version.WithLabelValues(version).Inc()
 
 	bs, err = ioutil.ReadFile(clPath)

--- a/config/config.toml
+++ b/config/config.toml
@@ -61,6 +61,8 @@ LogSpecialRecords = true
 PprofPort = 6000
 # Prometheus port
 PromPort = 9090
+# Switch to expose only small subset of essential metrics
+ShortMetrics = false
 
 # Histogram parameters for the host queue size
 HostQueueLengthBucketFactor = 3.0

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -39,8 +39,8 @@ type Main struct {
 	NormalizeRecords  bool
 	LogSpecialRecords bool
 
-	PprofPort   uint16
-	PromPort    uint16
+	PprofPort    uint16
+	PromPort     uint16
 	ShortMetrics bool
 
 	HostQueueLengthBucketFactor float64
@@ -93,8 +93,8 @@ func MakeDefault() Main {
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,
 
-		PprofPort:   6000,
-		PromPort:    9090,
+		PprofPort:    6000,
+		PromPort:     9090,
 		ShortMetrics: false,
 
 		HostQueueLengthBucketFactor: 3,

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -39,8 +39,9 @@ type Main struct {
 	NormalizeRecords  bool
 	LogSpecialRecords bool
 
-	PprofPort uint16
-	PromPort  uint16
+	PprofPort   uint16
+	PromPort    uint16
+	ShortMetrics bool
 
 	HostQueueLengthBucketFactor float64
 	HostQueueLengthBuckets      int
@@ -92,8 +93,9 @@ func MakeDefault() Main {
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,
 
-		PprofPort: 6000,
-		PromPort:  9090,
+		PprofPort:   6000,
+		PromPort:    9090,
+		ShortMetrics: false,
 
 		HostQueueLengthBucketFactor: 3,
 		HostQueueLengthBuckets:      10,

--- a/pkg/target/cluster.go
+++ b/pkg/target/cluster.go
@@ -160,6 +160,7 @@ func (cl *Cluster) addAvailableHost(host *Host) {
 		}
 	}
 	host.stateChanges.Inc()
+	host.stateChangesTotal.Inc()
 	cl.AvailableHosts = append(cl.AvailableHosts, host)
 }
 
@@ -169,6 +170,7 @@ func (cl *Cluster) removeAvailableHost(host *Host) {
 	for i, h := range cl.AvailableHosts {
 		if h == host {
 			host.stateChanges.Inc()
+			host.stateChangesTotal.Inc()
 			length := len(cl.AvailableHosts)
 
 			for j := i; j < length-1; j++ {

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -44,6 +44,7 @@ type Host struct {
 	throttled          prometheus.Counter
 	throttledTotal     prometheus.Counter
 	stateChanges       prometheus.Counter
+	stateChangesTotal  prometheus.Counter
 	processingDuration prometheus.Histogram
 	bufSize            int
 }
@@ -87,6 +88,7 @@ func NewHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.L
 		throttledTotal:            ms.ThrottledHostsTotal,
 		processingDuration:        ms.ProcessingDuration,
 		stateChanges:              ms.StateChangeHosts.With(promLabels),
+		stateChangesTotal:         ms.StateChangeHostsTotal,
 		bufSize:                   mainCfg.TCPOutBufSize,
 	}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
Introduces the ability to serve a  shortened set of metrics.

## How does this change solve the problem? Why is this the best approach?
Adds a flag in config that causes registration of only the select metrics.
It also adds total state changes metric.

## How can we be sure this works as expected?
local test