### PR TITLE
README: add example for running nanotube with rewrite rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build and run
 `make`
 3. Run it with
 
-`./nanotube -config config/config.toml -clusters config/clusters.toml -rules config/rules.toml`
+`./nanotube -config config/config.toml -clusters config/clusters.toml -rules config/rules.toml  -rewrites config/rewrite.toml`
 
 Running with docker-compose
 -----------------------------------


### PR DESCRIPTION
## What issue is this change attempting to solve?

We were missing example for running nanotube with rewrite rules argument. 
Even if we had this file in config example, it was not clear how to use it.

## How does this change solve the problem? Why is this the best approach?
This is the only example that we have for running nanotube.

## How can we be sure this works as expected?
Tested running with
`./nanotube -config config/config.toml -clusters config/clusters.toml -rules config/rules.toml -rewrites config/rewrite.toml`