### PR TITLE
Added check for send timeout to be larger than buf flush periond

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -36,6 +36,7 @@ WorkerPoolSize = 50
 # Timeout for dropping an incoming connection if no data is sent in.
 IncomingConnIdleTimeoutSec = 90
 # Timeout for sending data to target host via TCP connection.
+# Has to be > TCPOutBufFlushPeriodSec to allow enough time for the buffered records to be sent.
 SendTimeoutSec = 5
 # Timeout for connecting to a target host. Does not influence re-connections with exponential backoffs.
 OutConnTimeoutSec = 5

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -75,6 +75,9 @@ func ReadMain(r io.Reader) (Main, error) {
 	if cfg.ListenTCP == "" && cfg.ListenUDP == "" {
 		return cfg, errors.New("we don't listen neither on TCP nor on UDP")
 	}
+	if cfg.SendTimeoutSec <= cfg.TCPOutBufFlushPeriodSec {
+		return cfg, errors.New("TCP send timeout is lesser or equal to TCP buffer flush period")
+	}
 
 	return cfg, nil
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
Makes sure buffer is flushed before send is timed out on send. Fixes #54 

## How does this change solve the problem? Why is this the best approach?
Config check.

## How can we be sure this works as expected?
Simple test.

