### PR TITLE
Added host buffer flush on exit.

### DIFF
--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -119,6 +119,9 @@ func (h *Host) Stream(wg *sync.WaitGroup) {
 	for r := range h.Ch {
 		h.tryToSend(r)
 	}
+
+	// this line is only reached when the host channel was closed
+	h.tryToFlushIfNecessary()
 }
 
 func (h *Host) tryToSend(r *rec.Rec) {
@@ -182,15 +185,19 @@ func (h *Host) Flush(d time.Duration) {
 			return
 		case <-t.C:
 			h.CWm.Lock()
-			if h.Conn != nil && h.W != nil && h.W.Buffered() != 0 {
-				err := h.W.Flush()
-				if err != nil {
-					h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
-					h.Conn = nil
-					h.W = nil
-				}
-			}
+			h.tryToFlushIfNecessary()
 			h.CWm.Unlock()
+		}
+	}
+}
+
+func (h *Host) tryToFlushIfNecessary() {
+	if h.Conn != nil && h.W != nil && h.W.Buffered() != 0 {
+		err := h.W.Flush()
+		if err != nil {
+			h.Lg.Error("error while flushing the host buffer", zap.Error(err), zap.String("host name", h.Name), zap.Uint16("host port", h.Port))
+			h.Conn = nil
+			h.W = nil
 		}
 	}
 }

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -121,6 +121,8 @@ func (h *Host) Stream(wg *sync.WaitGroup) {
 	}
 
 	// this line is only reached when the host channel was closed
+	h.CWm.Lock()
+	defer h.CWm.Unlock()
 	h.tryToFlushIfNecessary()
 }
 
@@ -191,6 +193,7 @@ func (h *Host) Flush(d time.Duration) {
 	}
 }
 
+// Requires mCW mutex lock.
 func (h *Host) tryToFlushIfNecessary() {
 	if h.Conn != nil && h.W != nil && h.W.Buffered() != 0 {
 		err := h.W.Flush()


### PR DESCRIPTION
## What issue is this change attempting to solve?
All data is sent out on exit. Fixes #37 

## How does this change solve the problem? Why is this the best approach?
Host buffer is flushed on exit. It's an obvious thing to do.

## How can we be sure this works as expected?
Simple tests done.

