### PR TITLE
config: removing check for flags at invovation

### DIFF
--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -118,12 +118,6 @@ func parseFlags() (string, string, string, string, bool, bool) {
 	if cfgPath == nil || *cfgPath == "" {
 		log.Fatal("config file path not specified")
 	}
-	if clPath == nil || *clPath == "" {
-		log.Fatal("clusters file not specified")
-	}
-	if rulesPath == nil || *rulesPath == "" {
-		log.Fatal("rules file not specified")
-	}
 
 	return *cfgPath, *clPath, *rulesPath, *rewritesPath, *testConfig, false
 }


### PR DESCRIPTION
We are moving from many flags at invocation for
different config files to a main config file where
all other configs are specified.
This commit removes the check for clusters and rules
flags at invocation.
Related to #59

