### PR TITLE
Add separate config for lb cluster type period health check ticker

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -59,6 +59,8 @@ HostReconnectPeriodDeltaMs = 10
 # Threshold to indicate to cluster for host connection loss
 #Should be less than MaxHostReconnectPeriodMs
 ConnectionLossThresholdMs = 3000
+# LB cluster health check period
+LBClusterHealthCheckPeriodSec = 30
 
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true

--- a/config/config.toml
+++ b/config/config.toml
@@ -60,7 +60,7 @@ HostReconnectPeriodDeltaMs = 10
 #Should be less than MaxHostReconnectPeriodMs
 ConnectionLossThresholdMs = 3000
 # LB cluster health check period
-LBClusterHealthCheckPeriodSec = 30
+LBClusterHealthCheckPeriodSec = 10
 
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -27,14 +27,15 @@ type Main struct {
 
 	WorkerPoolSize uint16
 
-	IncomingConnIdleTimeoutSec uint32
-	SendTimeoutSec             uint32
-	OutConnTimeoutSec          uint32
-	MaxHostReconnectPeriodMs   uint32
-	HostReconnectPeriodDeltaMs uint32
-	KeepAliveSec               uint32
-	ConnectionLossThresholdMs  uint32
-	TermTimeoutSec             uint16
+	IncomingConnIdleTimeoutSec    uint32
+	SendTimeoutSec                uint32
+	OutConnTimeoutSec             uint32
+	MaxHostReconnectPeriodMs      uint32
+	LBClusterHealthCheckPeriodSec uint32
+	HostReconnectPeriodDeltaMs    uint32
+	KeepAliveSec                  uint32
+	ConnectionLossThresholdMs     uint32
+	TermTimeoutSec                uint16
 	// 0 value turns off buffering
 	TCPOutBufSize int
 	// 0 value turns off flushing
@@ -97,16 +98,17 @@ func MakeDefault() Main {
 		HostQueueSize:  1000,
 		WorkerPoolSize: 10,
 
-		IncomingConnIdleTimeoutSec: 90,
-		SendTimeoutSec:             5,
-		OutConnTimeoutSec:          5,
-		MaxHostReconnectPeriodMs:   5000,
-		HostReconnectPeriodDeltaMs: 10,
-		KeepAliveSec:               1,
-		ConnectionLossThresholdMs:  3000,
-		TermTimeoutSec:             10,
-		TCPOutBufSize:              0,
-		TCPOutBufFlushPeriodSec:    2,
+		IncomingConnIdleTimeoutSec:    90,
+		SendTimeoutSec:                5,
+		OutConnTimeoutSec:             5,
+		MaxHostReconnectPeriodMs:      5000,
+		LBClusterHealthCheckPeriodSec: 10,
+		HostReconnectPeriodDeltaMs:    10,
+		KeepAliveSec:                  1,
+		ConnectionLossThresholdMs:     3000,
+		TermTimeoutSec:                10,
+		TCPOutBufSize:                 0,
+		TCPOutBufFlushPeriodSec:       2,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -29,6 +29,7 @@ func TestConfSimple(t *testing.T) {
 	TCPOutBufFlushPeriodSec = 3
 	KeepAliveSec = 3
 	MaxHostReconnectPeriodMs = 777
+	LBClusterHealthCheckPeriodSec = 18
 	HostReconnectPeriodDeltaMs = 13
 	ConnectionLossThresholdMs = 200`
 
@@ -47,16 +48,17 @@ func TestConfSimple(t *testing.T) {
 
 		WorkerPoolSize: 10,
 
-		IncomingConnIdleTimeoutSec: 13,
-		SendTimeoutSec:             7,
-		OutConnTimeoutSec:          9,
-		TermTimeoutSec:             11,
-		TCPOutBufSize:              11,
-		TCPOutBufFlushPeriodSec:    3,
-		KeepAliveSec:               3,
-		MaxHostReconnectPeriodMs:   777,
-		HostReconnectPeriodDeltaMs: 13,
-		ConnectionLossThresholdMs:  200,
+		IncomingConnIdleTimeoutSec:    13,
+		SendTimeoutSec:                7,
+		OutConnTimeoutSec:             9,
+		TermTimeoutSec:                11,
+		TCPOutBufSize:                 11,
+		TCPOutBufFlushPeriodSec:       3,
+		KeepAliveSec:                  3,
+		MaxHostReconnectPeriodMs:      777,
+		LBClusterHealthCheckPeriodSec: 18,
+		HostReconnectPeriodDeltaMs:    13,
+		ConnectionLossThresholdMs:     200,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,

--- a/pkg/target/clusters.go
+++ b/pkg/target/clusters.go
@@ -66,7 +66,7 @@ func NewClusters(mainCfg conf.Main, cfg conf.Clusters, lg *zap.Logger, ms *metri
 	for _, cl := range cls {
 		go cl.keepAvailableHostsUpdated()
 		if cl.Type == conf.LB {
-			go cl.updateAvailableHostsPeriodically(time.Duration(mainCfg.MaxHostReconnectPeriodMs) * time.Millisecond)
+			go cl.updateAvailableHostsPeriodically(time.Duration(mainCfg.LBClusterHealthCheckPeriodSec) * time.Second)
 		}
 	}
 	return cls, err


### PR DESCRIPTION


## What issue is this change attempting to solve?
Currently, host reconnect period and lb health check period use the same config

## How does this change solve the problem? Why is this the best approach?
By separating these two, ability to control these two separately.

## How can we be sure this works as expected?
Tested, and default config is added as well.

