### PR TITLE
Expose nanotube version as part of 'less' metrics option.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -172,6 +172,11 @@ func Register(m *Prom, cfg *conf.Main) {
 		log.Fatalf("error registering the state_change_hosts_total metrics: %v", err)
 	}
 
+	err = prometheus.Register(m.Version)
+	if err != nil {
+		log.Fatalf("error registering the version metric: %v", err)
+	}
+
 	if !cfg.LessMetrics {
 		err = prometheus.Register(m.OutRecs)
 		if err != nil {
@@ -210,11 +215,6 @@ func Register(m *Prom, cfg *conf.Main) {
 		err = prometheus.Register(m.UDPReadFailures)
 		if err != nil {
 			log.Fatalf("error registering the udp_read_failures_total metric: %v", err)
-		}
-
-		err = prometheus.Register(m.Version)
-		if err != nil {
-			log.Fatalf("error registering the version metric: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
Version of nanotube should be exposed always.

## How does this change solve the problem? Why is this the best approach?
Version wasn't exposed if 'less' metrics option was enabled. It moves the serverprom metrics registration for this, out to common part.

## How can we be sure this works as expected?
Tested.
