### PR TITLE
Add option to measure regex time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@
 all:
 	go build -ldflags "-X main.version=$(shell git rev-parse HEAD)" ./cmd/nanotube
 
+.PHONY: install
+install:
+	go install ./cmd/nanotube
+	go install ./test/receiver
+	go install ./test/sender
+
 .PHONY: test
 test:
 	go test -cover -race ./...

--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -171,7 +171,7 @@ func loadBuildRegister(cfgPath string, lg *zap.Logger) (conf.Main, target.Cluste
 	if err != nil {
 		log.Fatalf("error reading rules config: %v", err)
 	}
-	rules, err := rules.Build(rulesConf, clusters)
+	rules, err := rules.Build(rulesConf, clusters, cfg.RegexDurationMetric, ms)
 	if err != nil {
 		log.Fatalf("error while compiling rules: %v", err)
 	}
@@ -186,7 +186,7 @@ func loadBuildRegister(cfgPath string, lg *zap.Logger) (conf.Main, target.Cluste
 		if err != nil {
 			log.Fatalf("error reading rewrites config: %v", err)
 		}
-		rewriteRules, err = rewrites.Build(rewritesConf)
+		rewriteRules, err = rewrites.Build(rewritesConf, cfg.RegexDurationMetric, ms)
 		if err != nil {
 			log.Fatalf("error while building rewrites: %v", err)
 		}

--- a/cmd/nanotube/process_test.go
+++ b/cmd/nanotube/process_test.go
@@ -39,7 +39,7 @@ func BenchmarkProcess(b *testing.B) {
 	}
 
 	rulesConf := conf.Rules{Rule: []conf.Rule{
-		conf.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",
@@ -55,7 +55,7 @@ func BenchmarkProcess(b *testing.B) {
 				"1",
 			},
 		},
-		conf.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",
@@ -66,7 +66,7 @@ func BenchmarkProcess(b *testing.B) {
 				"1", "2",
 			},
 		},
-		conf.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",

--- a/cmd/nanotube/process_test.go
+++ b/cmd/nanotube/process_test.go
@@ -14,6 +14,11 @@ import (
 )
 
 func BenchmarkProcess(b *testing.B) {
+	// TODO remove logging altogether to get real results
+	lg := zap.NewNop()
+	defaultConfig := conf.MakeDefault()
+	ms := metrics.New(&defaultConfig)
+
 	cls := target.Clusters{
 		"1": &target.Cluster{
 			Name: "1",
@@ -32,8 +37,9 @@ func BenchmarkProcess(b *testing.B) {
 			Type: conf.BlackholeCluster,
 		},
 	}
-	rules := rules.Rules{
-		rules.Rule{
+
+	rules := rules.NewFromSlice([]rules.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",
@@ -49,7 +55,7 @@ func BenchmarkProcess(b *testing.B) {
 				cls["1"],
 			},
 		},
-		rules.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",
@@ -61,7 +67,7 @@ func BenchmarkProcess(b *testing.B) {
 				cls["2"],
 			},
 		},
-		rules.Rule{
+		{
 			Regexs: []string{
 				".*",
 				".*",
@@ -77,12 +83,7 @@ func BenchmarkProcess(b *testing.B) {
 				cls["3"],
 			},
 		},
-	}
-
-	// TODO remove logging altogether to get real results
-	lg := zap.NewNop()
-	defaultConfig := conf.MakeDefault()
-	ms := metrics.New(&defaultConfig)
+	}, ms)
 
 	err := rules.Compile()
 	if err != nil {
@@ -96,6 +97,11 @@ func BenchmarkProcess(b *testing.B) {
 }
 
 func TestContinueRuleProcessing(t *testing.T) {
+	// TODO remove logging altogether to get real results
+	lg := zap.NewNop()
+	defaultConfig := conf.MakeDefault()
+	ms := metrics.New(&defaultConfig)
+
 	testMetric := "ab.c 123 123"
 	cls := target.Clusters{
 		"1": &target.Cluster{
@@ -115,8 +121,9 @@ func TestContinueRuleProcessing(t *testing.T) {
 			Type: conf.BlackholeCluster,
 		},
 	}
-	rules := rules.Rules{
-		rules.Rule{
+
+	rules := rules.NewFromSlice([]rules.Rule{
+		{
 			Regexs: []string{
 				"a.*",
 				"ab.*",
@@ -127,7 +134,7 @@ func TestContinueRuleProcessing(t *testing.T) {
 			},
 			Continue: true,
 		},
-		rules.Rule{
+		{
 			Regexs: []string{
 				"zz.*",
 				"ab.*",
@@ -137,12 +144,7 @@ func TestContinueRuleProcessing(t *testing.T) {
 				cls["2"],
 			},
 		},
-	}
-
-	// TODO remove logging altogether to get real results
-	lg := zap.NewNop()
-	defaultConfig := conf.MakeDefault()
-	ms := metrics.New(&defaultConfig)
+	}, ms)
 
 	err := rules.Compile()
 	if err != nil {
@@ -160,6 +162,11 @@ func TestContinueRuleProcessing(t *testing.T) {
 }
 
 func TestStopRuleProcessing(t *testing.T) {
+	// TODO remove logging altogether to get real results
+	lg := zap.NewNop()
+	defaultConfig := conf.MakeDefault()
+	ms := metrics.New(&defaultConfig)
+
 	testMetric := " ab.c 123 123"
 	cls := target.Clusters{
 		"1": &target.Cluster{
@@ -179,8 +186,9 @@ func TestStopRuleProcessing(t *testing.T) {
 			Type: conf.BlackholeCluster,
 		},
 	}
-	rules := rules.Rules{
-		rules.Rule{
+
+	rules := rules.NewFromSlice([]rules.Rule{
+		{
 			Regexs: []string{
 				"a.*",
 				"ab.*",
@@ -189,7 +197,7 @@ func TestStopRuleProcessing(t *testing.T) {
 			Targets: []*target.Cluster{cls["1"]},
 			//Continue: false,
 		},
-		rules.Rule{
+		{
 			Regexs: []string{
 				"zz.*",
 				"ab.*",
@@ -200,12 +208,7 @@ func TestStopRuleProcessing(t *testing.T) {
 			},
 			Continue: true,
 		},
-	}
-
-	// TODO remove logging altogether to get real results
-	lg := zap.NewNop()
-	defaultConfig := conf.MakeDefault()
-	ms := metrics.New(&defaultConfig)
+	}, ms)
 
 	err := rules.Compile()
 	if err != nil {
@@ -223,6 +226,11 @@ func TestStopRuleProcessing(t *testing.T) {
 }
 
 func TestRewriteNoCopy(t *testing.T) {
+	// TODO remove logging altogether to get real results
+	lg := zap.NewNop()
+	defaultConfig := conf.MakeDefault()
+	ms := metrics.New(&defaultConfig)
+
 	testMetric := "ab.c 123 123"
 	cls := target.Clusters{
 		"1": &target.Cluster{
@@ -231,26 +239,21 @@ func TestRewriteNoCopy(t *testing.T) {
 		},
 	}
 
-	rules := rules.Rules{
-		rules.Rule{
+	rules := rules.NewFromSlice([]rules.Rule{
+		{
 			Regexs: []string{
 				"de",
 			},
 			Targets: []*target.Cluster{cls["1"]}},
-	}
+	}, ms)
 
-	rewrites := rewrites.Rewrites{
-		rewrites.Rewrite{
+	rewrites := rewrites.NewFromSlice([]rewrites.Rewrite{
+		{
 			From: "ab.c",
 			To:   "de",
 			Copy: false,
 		},
-	}
-
-	// TODO remove logging altogether to get real results
-	lg := zap.NewNop()
-	defaultConfig := conf.MakeDefault()
-	ms := metrics.New(&defaultConfig)
+	}, ms)
 
 	err := rules.Compile()
 	if err != nil {
@@ -271,6 +274,11 @@ func TestRewriteNoCopy(t *testing.T) {
 }
 
 func TestRewriteCopy(t *testing.T) {
+	// TODO remove logging altogether to get real results
+	lg := zap.NewNop()
+	defaultConfig := conf.MakeDefault()
+	ms := metrics.New(&defaultConfig)
+
 	testMetric := "ab.c 123 123"
 	cls := target.Clusters{
 		"1": &target.Cluster{
@@ -279,27 +287,22 @@ func TestRewriteCopy(t *testing.T) {
 		},
 	}
 
-	rules := rules.Rules{
-		rules.Rule{
+	rules := rules.NewFromSlice([]rules.Rule{
+		{
 			Regexs: []string{
 				"de",
 				"ab.c",
 			},
 			Targets: []*target.Cluster{cls["1"]}},
-	}
+	}, ms)
 
-	rewrites := rewrites.Rewrites{
-		rewrites.Rewrite{
+	rewrites := rewrites.NewFromSlice([]rewrites.Rewrite{
+		{
 			From: "ab.c",
 			To:   "de",
 			Copy: true,
 		},
-	}
-
-	// TODO remove logging altogether to get real results
-	lg := zap.NewNop()
-	defaultConfig := conf.MakeDefault()
-	ms := metrics.New(&defaultConfig)
+	}, ms)
 
 	err := rules.Compile()
 	if err != nil {

--- a/config/config.toml
+++ b/config/config.toml
@@ -3,7 +3,7 @@
 # WARNING: This is a sample config. You most likely need to tweak it for your use case.
 
 # Clusters config path. Mandatory.
-ClustersConfig = "config/clusters.toml" 
+ClustersConfig = "config/clusters.toml"
 # Clusters config path. Mandatory.
 RulesConfig = "config/rules.toml"
 # Rewrites config path. Optional.
@@ -74,7 +74,9 @@ PromPort = 9090
 # Switch to expose only small subset of essential metrics.
 # (Useful to reduce Prometheus load when running as a sidecar on many nodes in a large setup.)
 LessMetrics = false
-
+# Explose prometheus metrcs with the total time for running each regex from config.
+# Can be used to understand what regexs from config are more 'expensive'
+RegexDurationMetric = false
 # Histogram parameters for the host queue size
 HostQueueLengthBucketFactor = 3.0
 HostQueueLengthBuckets = 10

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -45,9 +45,10 @@ type Main struct {
 	LogSpecialRecords bool
 
 	// -1 turns off pprof server
-	PprofPort   int
-	PromPort    int
-	LessMetrics bool
+	PprofPort           int
+	PromPort            int
+	LessMetrics         bool
+	RegexDurationMetric bool
 
 	HostQueueLengthBucketFactor float64
 	HostQueueLengthBuckets      int
@@ -113,9 +114,10 @@ func MakeDefault() Main {
 		NormalizeRecords:  true,
 		LogSpecialRecords: true,
 
-		PprofPort:   -1,
-		PromPort:    9090,
-		LessMetrics: false,
+		PprofPort:           -1,
+		PromPort:            9090,
+		LessMetrics:         false,
+		RegexDurationMetric: false,
 
 		HostQueueLengthBucketFactor: 3,
 		HostQueueLengthBuckets:      10,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,6 +33,8 @@ type Prom struct {
 	UDPReadFailures prometheus.Counter
 
 	Version *prometheus.CounterVec
+
+	RegexDuration *prometheus.HistogramVec
 }
 
 // New creates a new set of metrics from the main config.
@@ -126,6 +128,12 @@ func New(conf *conf.Main) *Prom {
 			Name:      "version",
 			Help:      "Version info in label. Value should be always 1.",
 		}, []string{"version"}),
+		RegexDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "nanotube",
+			Name:      "regex_duration_seconds",
+			Help:      "Time to evaluate each regex from configuration",
+			Buckets:   []float64{0},
+		}, []string{"regex", "rule_type"}),
 	}
 }
 
@@ -215,6 +223,13 @@ func Register(m *Prom, cfg *conf.Main) {
 		err = prometheus.Register(m.UDPReadFailures)
 		if err != nil {
 			log.Fatalf("error registering the udp_read_failures_total metric: %v", err)
+		}
+
+		if cfg.RegexDurationMetric {
+			err = prometheus.Register(m.RegexDuration)
+			if err != nil {
+				log.Fatalf("error register the RegexDuration metric")
+			}
 		}
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -34,7 +34,7 @@ type Prom struct {
 
 	Version *prometheus.CounterVec
 
-	RegexDuration *prometheus.HistogramVec
+	RegexDuration *prometheus.SummaryVec
 }
 
 // New creates a new set of metrics from the main config.
@@ -128,11 +128,10 @@ func New(conf *conf.Main) *Prom {
 			Name:      "version",
 			Help:      "Version info in label. Value should be always 1.",
 		}, []string{"version"}),
-		RegexDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		RegexDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace: "nanotube",
 			Name:      "regex_duration_seconds",
 			Help:      "Time to evaluate each regex from configuration",
-			Buckets:   []float64{0},
 		}, []string{"regex", "rule_type"}),
 	}
 }

--- a/pkg/rewrites/rewrites.go
+++ b/pkg/rewrites/rewrites.go
@@ -5,13 +5,19 @@ import (
 	"regexp"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
+	"github.com/bookingcom/nanotube/pkg/metrics"
 	"github.com/bookingcom/nanotube/pkg/rec"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Rewrites represent all the routing rewrites/routing table.
-type Rewrites []Rewrite
+type Rewrites struct {
+	rewrites     []Rewrite
+	measureRegex bool
+	metrics      *metrics.Prom
+}
 
 // Rewrite is a routing rewrite.
 type Rewrite struct {
@@ -19,12 +25,18 @@ type Rewrite struct {
 	To   string
 	Copy bool
 
-	CompiledFrom *regexp.Regexp
+	CompiledFrom    *regexp.Regexp
+	matchDuration   prometheus.Observer
+	replaceDuration prometheus.Observer
 }
 
 // Build reads rewrite rules from config, compiles them.
-func Build(crw conf.Rewrites) (Rewrites, error) {
+func Build(crw conf.Rewrites, measureRegex bool, metrics *metrics.Prom) (Rewrites, error) {
 	var rw Rewrites
+
+	rw.measureRegex = measureRegex
+	rw.metrics = metrics
+
 	for _, cr := range crw.Rewrite {
 		r := Rewrite{
 			From: cr.From,
@@ -32,7 +44,7 @@ func Build(crw conf.Rewrites) (Rewrites, error) {
 			Copy: cr.Copy,
 		}
 
-		rw = append(rw, r)
+		rw.rewrites = append(rw.rewrites, r)
 	}
 
 	err := rw.Compile()
@@ -43,27 +55,60 @@ func Build(crw conf.Rewrites) (Rewrites, error) {
 	return rw, nil
 }
 
+// NewFromSlice build a Rewrites struct from a slice of Rewrites. Used in tests
+func NewFromSlice(rewrites []Rewrite, ms *metrics.Prom) Rewrites {
+	return Rewrites{
+		rewrites:     rewrites,
+		measureRegex: false,
+		metrics:      ms,
+	}
+}
+
 // Compile precompiles regexps
 func (rw Rewrites) Compile() error {
-	for i, r := range rw {
+	for i, r := range rw.rewrites {
 		cre, err := regexp.Compile(r.From)
 		if err != nil {
 			return errors.Wrapf(err, "compiling rewrite regex: %s failed", cre)
 		}
-		rw[i].CompiledFrom = cre
+		rw.rewrites[i].CompiledFrom = cre
+		if rw.measureRegex {
+			rw.rewrites[i].matchDuration = rw.metrics.RegexDuration.With(prometheus.Labels{
+				"rule_type": "rewrite_match",
+				"regex":     r.From,
+			})
+			rw.rewrites[i].replaceDuration = rw.metrics.RegexDuration.With(prometheus.Labels{
+				"rule_type": "rewrite_replace",
+				"regex":     r.From + " :: " + r.To,
+			})
+		}
 	}
-
 	return nil
 }
 
 // RewriteMetric executes all rewrite rules on a record
 // If copy is true and rule matches, we generate new record
 func (rw Rewrites) RewriteMetric(record *rec.Rec) []*rec.Rec {
+	var timer *prometheus.Timer
+
 	result := []*rec.Rec{record}
 
-	for _, r := range rw {
-		if r.CompiledFrom.MatchString(record.Path) {
+	for _, r := range rw.rewrites {
+		if rw.measureRegex {
+			timer = prometheus.NewTimer(r.matchDuration)
+		}
+		matched := r.CompiledFrom.MatchString(record.Path)
+		if rw.measureRegex {
+			timer.ObserveDuration()
+		}
+		if matched {
+			if rw.measureRegex {
+				timer = prometheus.NewTimer(r.replaceDuration)
+			}
 			newPath := r.CompiledFrom.ReplaceAllString(record.Path, r.To)
+			if rw.measureRegex {
+				timer.ObserveDuration()
+			}
 			if r.Copy {
 				// keep both old and new value
 				copy := record.Copy()

--- a/pkg/rewrites/rewrites.go
+++ b/pkg/rewrites/rewrites.go
@@ -47,7 +47,7 @@ func Build(crw conf.Rewrites, measureRegex bool, metrics *metrics.Prom) (Rewrite
 		rw.rewrites = append(rw.rewrites, r)
 	}
 
-	err := rw.Compile()
+	err := rw.compile()
 	if err != nil {
 		return rw, errors.Wrap(err, "rewrite rule compilation failed :")
 	}
@@ -55,17 +55,8 @@ func Build(crw conf.Rewrites, measureRegex bool, metrics *metrics.Prom) (Rewrite
 	return rw, nil
 }
 
-// NewFromSlice build a Rewrites struct from a slice of Rewrites. Used in tests
-func NewFromSlice(rewrites []Rewrite, ms *metrics.Prom) Rewrites {
-	return Rewrites{
-		rewrites:     rewrites,
-		measureRegex: false,
-		metrics:      ms,
-	}
-}
-
-// Compile precompiles regexps
-func (rw Rewrites) Compile() error {
+// compile precompiles regexps
+func (rw Rewrites) compile() error {
 	for i, r := range rw.rewrites {
 		cre, err := regexp.Compile(r.From)
 		if err != nil {

--- a/pkg/rewrites/rewrites_test.go
+++ b/pkg/rewrites/rewrites_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
+	"github.com/bookingcom/nanotube/pkg/metrics"
 	"github.com/bookingcom/nanotube/pkg/rec"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,8 +55,11 @@ func TestRewrites(t *testing.T) {
 		},
 	}
 
+	cfg := conf.MakeDefault()
+	ms := metrics.New(&cfg)
+
 	for _, test := range tests {
-		rewrites, err := Build(rewrites[test.rewrites])
+		rewrites, err := Build(rewrites[test.rewrites], false, ms)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -5,27 +5,40 @@ import (
 	"fmt"
 	"regexp"
 
+	"go.uber.org/zap"
+
 	"github.com/bookingcom/nanotube/pkg/conf"
+	"github.com/bookingcom/nanotube/pkg/metrics"
 	"github.com/bookingcom/nanotube/pkg/rec"
 	"github.com/bookingcom/nanotube/pkg/target"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Rules represent all the routing rules/routing table.
-type Rules []Rule
+type Rules struct {
+	rules        []Rule
+	measureRegex bool
+	metrics      *metrics.Prom
+}
 
 // Rule is a routing rule.
 type Rule struct {
-	Regexs     []string
-	Targets    []*target.Cluster
-	Continue   bool
-	CompiledRE []*regexp.Regexp
+	Regexs        []string
+	Targets       []*target.Cluster
+	Continue      bool
+	CompiledRE    []*regexp.Regexp
+	regexDuration []prometheus.Observer
 }
 
 // Build reads rules from config, compiles them.
-func Build(crs conf.Rules, clusters target.Clusters) (Rules, error) {
+func Build(crs conf.Rules, clusters target.Clusters, measureRegex bool, ms *metrics.Prom) (Rules, error) {
 	var rs Rules
+
+	rs.measureRegex = measureRegex
+	rs.metrics = ms
+
 	for _, cr := range crs.Rule {
 		r := Rule{
 			Regexs:   cr.Regexs,
@@ -41,7 +54,7 @@ func Build(crs conf.Rules, clusters target.Clusters) (Rules, error) {
 			r.Targets = append(r.Targets, cl)
 		}
 
-		rs = append(rs, r)
+		rs.rules = append(rs.rules, r)
 	}
 
 	err := rs.Compile()
@@ -52,26 +65,81 @@ func Build(crs conf.Rules, clusters target.Clusters) (Rules, error) {
 	return rs, nil
 }
 
+// NewFromSlice builds new rules list from slice of rules. Used in tests
+func NewFromSlice(rules []Rule, ms *metrics.Prom) Rules {
+	return Rules{
+		rules:        rules,
+		measureRegex: false,
+		metrics:      ms,
+	}
+}
+
 // Compile precompiles regexps for perf and performs validation.
 func (rs Rules) Compile() error {
-	for i := range rs {
-		rs[i].CompiledRE = make([]*regexp.Regexp, 0)
-		for _, re := range rs[i].Regexs {
+	for i := range rs.rules {
+		rs.rules[i].CompiledRE = make([]*regexp.Regexp, 0)
+		for _, re := range rs.rules[i].Regexs {
 			cre, err := regexp.Compile(re)
 			if err != nil {
 				return errors.Wrapf(err, "compiling regex %s failed", cre)
 			}
-			rs[i].CompiledRE = append(rs[i].CompiledRE, cre)
+			rs.rules[i].CompiledRE = append(rs.rules[i].CompiledRE, cre)
+			if rs.measureRegex {
+				labels := prometheus.Labels{
+					"rule_type": "routing",
+					"regex":     re,
+				}
+				rs.rules[i].regexDuration = append(rs.rules[i].regexDuration, rs.metrics.RegexDuration.With(labels))
+			}
 		}
 	}
 
 	return nil
 }
 
+// RouteRec a record by following the rules
+func (rs Rules) RouteRec(r *rec.Rec, lg *zap.Logger) {
+	pushedTo := make(map[*target.Cluster]struct{})
+
+	for _, rl := range rs.rules {
+		matchedRule := rl.Match(r, rs.measureRegex)
+		if matchedRule {
+			for _, cl := range rl.Targets {
+				if _, pushedBefore := pushedTo[cl]; pushedBefore {
+					continue
+				}
+				fmt.Printf("push: %v", cl)
+				err := cl.Push(r, rs.metrics)
+				if err != nil {
+					lg.Error("push to cluster failed",
+						zap.Error(err),
+						zap.String("cluster", cl.Name),
+						zap.String("record", r.Serialize()))
+				}
+				pushedTo[cl] = struct{}{}
+			}
+		}
+
+		if matchedRule && !rl.Continue {
+			break
+		}
+	}
+}
+
 // Match a record with any of the rule regexps
-func (rl Rule) Match(r *rec.Rec) bool {
-	for _, re := range rl.CompiledRE {
-		if re.MatchString(r.Path) {
+func (rl Rule) Match(r *rec.Rec, measureRegex bool) bool {
+	var timer *prometheus.Timer
+
+	for idx, re := range rl.CompiledRE {
+		// XXX measure regex
+		if measureRegex {
+			timer = prometheus.NewTimer(rl.regexDuration[idx])
+		}
+		matched := re.MatchString(r.Path)
+		if measureRegex {
+			timer.ObserveDuration()
+		}
+		if matched {
 			return true
 		}
 	}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -130,7 +130,6 @@ func (rl Rule) Match(r *rec.Rec, measureRegex bool) bool {
 	var timer *prometheus.Timer
 
 	for idx, re := range rl.CompiledRE {
-		// XXX measure regex
 		if measureRegex {
 			timer = prometheus.NewTimer(rl.regexDuration[idx])
 		}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -108,7 +108,6 @@ func (rs Rules) RouteRec(r *rec.Rec, lg *zap.Logger) {
 				if _, pushedBefore := pushedTo[cl]; pushedBefore {
 					continue
 				}
-				fmt.Printf("push: %v", cl)
 				err := cl.Push(r, rs.metrics)
 				if err != nil {
 					lg.Error("push to cluster failed",

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -57,7 +57,7 @@ func Build(crs conf.Rules, clusters target.Clusters, measureRegex bool, ms *metr
 		rs.rules = append(rs.rules, r)
 	}
 
-	err := rs.Compile()
+	err := rs.compile()
 	if err != nil {
 		return rs, errors.Wrap(err, "rules compilation failed :")
 	}
@@ -65,17 +65,8 @@ func Build(crs conf.Rules, clusters target.Clusters, measureRegex bool, ms *metr
 	return rs, nil
 }
 
-// NewFromSlice builds new rules list from slice of rules. Used in tests
-func NewFromSlice(rules []Rule, ms *metrics.Prom) Rules {
-	return Rules{
-		rules:        rules,
-		measureRegex: false,
-		metrics:      ms,
-	}
-}
-
-// Compile precompiles regexps for perf and performs validation.
-func (rs Rules) Compile() error {
+// compile precompiles regexps for perf and performs validation.
+func (rs Rules) compile() error {
 	for i := range rs.rules {
 		rs.rules[i].CompiledRE = make([]*regexp.Regexp, 0)
 		for _, re := range rs.rules[i].Regexs {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -106,7 +106,7 @@ func TestRules(t *testing.T) {
 				t.Fatalf("rules building failed: %v", err)
 			}
 
-			err = rs.Compile()
+			err = rs.compile()
 			if err != nil {
 				t.Fatalf("compiling rules failed: %v", err)
 			}

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -101,7 +101,7 @@ func TestRules(t *testing.T) {
 			if err != nil {
 				t.Fatalf("building clusters failed: %v", err)
 			}
-			rs, err := Build(tt.crules, clusters)
+			rs, err := Build(tt.crules, clusters, false, ms)
 			if err != nil {
 				t.Fatalf("rules building failed: %v", err)
 			}
@@ -111,19 +111,19 @@ func TestRules(t *testing.T) {
 				t.Fatalf("compiling rules failed: %v", err)
 			}
 
-			if len(rs) != tt.nRules {
-				t.Fatalf("expected %d rules, got %d", 2, len(rs))
+			if len(rs.rules) != tt.nRules {
+				t.Fatalf("expected %d rules, got %d", 2, len(rs.rules))
 			}
 
 			for i, n := range tt.nRegexs {
-				if len(rs[i].Regexs) != n {
-					t.Fatalf("expected %d regexs in the rule, got %d", n, len(rs[i].Regexs))
+				if len(rs.rules[i].Regexs) != n {
+					t.Fatalf("expected %d regexs in the rule, got %d", n, len(rs.rules[i].Regexs))
 				}
 			}
 
 			for i, n := range tt.nClusters {
-				if len(rs[i].Targets) != n {
-					t.Fatalf("expecte %d clusters in the rule, got %d", n, len(rs[i].Targets))
+				if len(rs.rules[i].Targets) != n {
+					t.Fatalf("expecte %d clusters in the rule, got %d", n, len(rs.rules[i].Targets))
 				}
 			}
 		})


### PR DESCRIPTION
## What issue is this change attempting to solve?

When profiling nanotube we see that most of the time is spent on evaluating regexes.
The issue is that some regex can take 10x time to evaluate vs. others. 
If we add a metric to measure time to execute each regex, we can then look into optimizing them.

## How does this change solve the problem? Why is this the best approach?

If we enable RegexDurationMetric config option
we are going to expose one histogram for each regex from config.

That way, we can see what regex takes more time to execute and look into
rewriting them.

I'm using histogram here with one single bucket of 0 because having
'sum' and 'count' should give us enough data.

## How can we be sure this works as expected?
Tested by hand.
Output from corectness test:
```
Finished running test for the second Nanotube.
Comparing the first and the second Nanotube outputs...
SUCCESS! Outputs are the same.
```
Tested on a production server.