### PR TITLE
Optimized UDP buf dynamics. Added benchmark.

### DIFF
--- a/cmd/nanotube/listen.go
+++ b/cmd/nanotube/listen.go
@@ -146,7 +146,7 @@ func listenUDP(conn net.Conn, queue chan string, stop <-chan struct{},
 
 		select {
 		case <-stop:
-			break
+			return
 		default:
 		}
 	}

--- a/cmd/nanotube/listen_test.go
+++ b/cmd/nanotube/listen_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/bookingcom/nanotube/pkg/conf"
+	"github.com/bookingcom/nanotube/pkg/metrics"
+
+	"go.uber.org/zap"
+)
+
+func BenchmarkListenUDP(b *testing.B) {
+	server, conn := net.Pipe()
+	q := make(chan string, 10000)
+	stop := make(chan struct{})
+	lg := zap.NewNop()
+	cfg := conf.MakeDefault()
+	ms := metrics.New(&cfg)
+
+	go func() {
+		listenUDP(conn, q, stop, 4096, lg, ms)
+	}()
+
+	rec := []byte("aaa.bbb.ccc 1 12345678\n")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		server.Write(rec)
+		<-q
+	}
+	b.StopTimer()
+
+	server.Close()
+}

--- a/cmd/nanotube/listen_test.go
+++ b/cmd/nanotube/listen_test.go
@@ -25,10 +25,16 @@ func BenchmarkListenUDP(b *testing.B) {
 	rec := []byte("aaa.bbb.ccc 1 12345678\n")
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		server.Write(rec)
+		_, err := server.Write(rec)
+		if err != nil {
+			b.Fatal("writing to test connection failed", err)
+		}
 		<-q
 	}
 	b.StopTimer()
 
-	server.Close()
+	err := server.Close()
+	if err != nil {
+		b.Fatal("closing test server failed", err)
+	}
 }


### PR DESCRIPTION
The benchmark before and after:
```
BenchmarkListenUDP-8   	   23498	     48324 ns/op  514072 B/op	      10 allocs/op
BenchmarkListenUDP-8   	  689814	     1873 ns/op	    1176 B/op	      19 allocs/op
```

Fixes #77 