### PR TITLE
Changed termination sequence to accomodate for UDP. Fixed logger sync error.

### DIFF
--- a/cmd/nanotube/listen_test.go
+++ b/cmd/nanotube/listen_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
@@ -17,9 +18,11 @@ func BenchmarkListenUDP(b *testing.B) {
 	lg := zap.NewNop()
 	cfg := conf.MakeDefault()
 	ms := metrics.New(&cfg)
+	var wg sync.WaitGroup
 
+	wg.Add(1)
 	go func() {
-		listenUDP(conn, q, stop, lg, ms)
+		listenUDP(conn, q, stop, &wg, ms, lg)
 	}()
 
 	rec := []byte("aaa.bbb.ccc 1 12345678\n")

--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -31,12 +31,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("error building logger config: %v", err)
 	}
-	defer func() {
-		err := lg.Sync()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error when syncing logger: %v", err)
-		}
-	}()
 
 	cfgPath, _, _, _, validateConfig, versionInfo := parseFlags()
 


### PR DESCRIPTION
Fixes #78, makes the termination sequence function correctly with UDP.
Fixes logger sync failure after termination.
Fixes #67 