### PR TITLE
Added matching by prefix + benchmarks + cluster mocking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Please refer to the [sample config](config/config.toml) for examples and documen
 
 Is defined in the [rules config](config/rules.toml) that is in turn referred to in the [main config](config/config.toml). This is how it works:
 
-- routing rules are applied to each incoming record in order;
-  - if regex in a rule matches, the record is sent to the clusters in the `clusters` list;
-    - if `continue` is `true` continue matching next rules, stop otherwise. `false` is the default;
-  - if regex does not match, continue down the list of rules;
-- multiple rules can be matched to each record;
-- each record can be sent to a single cluster at most once. If two rules send it to same cluster, only one instance will be sent;
-- cluster names must be from the set defined in the [clusters config](clonfig/clusters.toml);
+- Routing rules are applied to each incoming record in order;
+  - If regex or prefix in a rule matches, the record is sent to the clusters in the `clusters` list;
+    - If `continue` is `true` continue matching next rules, stop otherwise. `false` is the default;
+  - If no regex or prefix matches, continue down the list of rules;
+- Multiple rules can be matched to each record;
+- Each record is sent to a single cluster only once. If two rules send it to same cluster, only one instance will be sent;
+- Cluster names must be from the set in the [clusters config](clonfig/clusters.toml).
 
 ### Rewrites
 

--- a/cmd/nanotube/process.go
+++ b/cmd/nanotube/process.go
@@ -48,6 +48,4 @@ func proc(s string, rules rules.Rules, rewrites rewrites.Rewrites, shouldNormali
 	for _, rec := range recs {
 		rules.RouteRec(rec, lg)
 	}
-
-	// TODO: counter for dropped metrics
 }

--- a/config/config.toml
+++ b/config/config.toml
@@ -7,7 +7,8 @@ ClustersConfig = "config/clusters.toml"
 # Clusters config path. Mandatory.
 RulesConfig = "config/rules.toml"
 # Rewrites config path. Optional.
-RewritesConfig = "config/rewrite.toml"
+RewritesConfig = ""
+# RewritesConfig = "config/rewrite.toml" to enable
 
 # The default target port on receiver hosts. Can be overridden in the clusters setup.
 TargetPort = 2004

--- a/config/config.toml
+++ b/config/config.toml
@@ -7,7 +7,7 @@ ClustersConfig = "config/clusters.toml"
 # Clusters config path. Mandatory.
 RulesConfig = "config/rules.toml"
 # Rewrites config path. Optional.
-RewritesConfig = ""
+RewritesConfig = "config/rewrite.toml"
 
 # The default target port on receiver hosts. Can be overridden in the clusters setup.
 TargetPort = 2004

--- a/config/rules.toml
+++ b/config/rules.toml
@@ -1,27 +1,48 @@
 [[rule]]
+    # Only one regex has to match to send the record. Order does not matter.
     regexs = [
-        '.*a.*'
+        '.*a.*',
+        '^abc\.def\.'
     ]
     clusters = [
+        # Matching records will be sent here.
         'local0'
     ]
+    # If true, even if there is a match, we continue to the next rule.
     continue = true
 
 [[rule]]
-    regexs = [
-        '.*b.*'
+    # Prefix matching can be used instead of regex to match prefixes.
+    # Prefix matching is faster than prefix matching.
+    prefixes = [
+        'abc',
+        'xyz',
+        'poi'
     ]
     clusters = [
         'local1'
     ]
 
 [[rule]]
+    # This does the same as the previous regex, but is slower.
     regexs = [
-        '^abc.*'
+        '^abc.*',
+        '^xyz.*',
+        '^poi.*'
     ]
+    clusters = [
+        'local1'
+    ]
+
+# Prefixes and regexs can be mixed. Either has to match, i.e. they use OR logic.
+# Order does not matter.
+[[rule]]
     prefixes = [
         'xyz',
         'poi'
+    ]
+    regexs = [
+        '^abc.*'
     ]
     clusters = [
         'local1'

--- a/config/rules.toml
+++ b/config/rules.toml
@@ -15,3 +15,14 @@
         'local1'
     ]
 
+[[rule]]
+    regexs = [
+        '^abc.*'
+    ]
+    prefixes = [
+        'xyz',
+        'poi'
+    ]
+    clusters = [
+        'local1'
+    ]

--- a/config/rules.toml
+++ b/config/rules.toml
@@ -13,7 +13,7 @@
 
 [[rule]]
     # Prefix matching can be used instead of regex to match prefixes.
-    # Prefix matching is faster than prefix matching.
+    # Prefix matching is faster than regex matching.
     prefixes = [
         'abc',
         'xyz',

--- a/pkg/conf/rules.go
+++ b/pkg/conf/rules.go
@@ -16,6 +16,7 @@ type Rules struct {
 // Rule in configuration for a single rule.
 type Rule struct {
 	Regexs   []string
+	Prefixes []string
 	Clusters []string
 	Continue bool
 }
@@ -31,8 +32,8 @@ func ReadRules(r io.Reader) (Rules, error) {
 		return rs, fmt.Errorf("no rules specified in the rules file")
 	}
 	for idx, rule := range rs.Rule {
-		if len(rule.Regexs) == 0 {
-			return rs, fmt.Errorf("rule %d is missing 'regexs' section", idx)
+		if len(rule.Regexs) == 0 && len(rule.Prefixes) == 0 {
+			return rs, fmt.Errorf("rule %d is missing both 'regexs' and 'prefixes' sections", idx)
 		}
 		if len(rule.Clusters) == 0 {
 			return rs, fmt.Errorf("rule %d is missing 'clusters' section", idx)

--- a/pkg/conf/rules_test.go
+++ b/pkg/conf/rules_test.go
@@ -24,6 +24,10 @@ func TestRulesSimple(t *testing.T) {
 		"^abc$",
 		"^cbd*df$"
 	]
+	prefixes = [
+		"xyz",
+		"oiu"
+	]
 	clusters = [
 		"aaa",
 		"bbb"
@@ -45,6 +49,10 @@ func TestRulesSimple(t *testing.T) {
 				Regexs: []string{
 					"^abc$",
 					"^cbd*df$",
+				},
+				Prefixes: []string{
+					"xyz",
+					"oiu",
 				},
 				Clusters: []string{
 					"aaa",


### PR DESCRIPTION
## What issue is this change attempting to solve?
* Improve performance
* Improve testing
* Add meaningful benchmarks
* Less prot problems when running unit-tests

## How does this change solve the problem? Why is this the best approach?
* Added prefix matching in addition to regex matching for routing
* Added mock for clusters
* Added better benchmarks

## How can we be sure this works as expected?
BenchmarkProcessREs-8      	   82740	     14287 ns/op	    3448 B/op	      85 allocs/op
BenchmarkProcessPrefix-8   	  130736	      9434 ns/op	    3424 B/op	      85 allocs/op

Additional tests pass.