### PR TITLE
Added metric exposing hash of all the confgs. This can be used to track config versions and updates.

### DIFF
--- a/cmd/nanotube/main_test.go
+++ b/cmd/nanotube/main_test.go
@@ -46,7 +46,7 @@ func setup(t *testing.T) {
 
 	cfgPath := filepath.Join(fixturesPath, "config.toml")
 
-	cfg, clusters, rules, rewrites, ms, err := loadBuildRegister(cfgPath, lg)
+	cfg, clusters, rules, rewrites, ms, _, err := loadBuildRegister(cfgPath, lg)
 	if err != nil {
 		t.Fatalf("failed to build config: %v", err)
 	}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"crypto/md5"
+	"fmt"
 	"io"
 
 	"github.com/burntsushi/toml"
@@ -125,4 +127,14 @@ func MakeDefault() Main {
 		ProcessingDurationBucketFactor: 2,
 		ProcessingDurationBuckets:      10,
 	}
+}
+
+// Hash calculates hash of all the configs to track config versions.
+func Hash(cfg *Main, clusters *Clusters, rules *Rules, rewrites *Rewrites) (string, error) {
+	h := md5.New()
+	_, err := h.Write([]byte(fmt.Sprintf("%v%v%v%v", cfg, clusters, rules, rewrites)))
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate config hash: %w", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,9 +32,10 @@ type Prom struct {
 
 	UDPReadFailures prometheus.Counter
 
-	Version *prometheus.CounterVec
-
 	RegexDuration *prometheus.SummaryVec
+
+	Version     *prometheus.CounterVec
+	ConfVersion *prometheus.CounterVec
 }
 
 // New creates a new set of metrics from the main config.
@@ -123,16 +124,21 @@ func New(conf *conf.Main) *Prom {
 			Name:      "udp_read_failures_total",
 			Help:      "Counter of failures when reading incoming data from the UDP connection.",
 		}),
-		Version: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "nanotube",
-			Name:      "version",
-			Help:      "Version info in label. Value should be always 1.",
-		}, []string{"version"}),
 		RegexDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace: "nanotube",
 			Name:      "regex_duration_seconds",
 			Help:      "Time to evaluate each regex from configuration",
 		}, []string{"regex", "rule_type"}),
+		Version: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "nanotube",
+			Name:      "version",
+			Help:      "Version info in label. Value should be always 1.",
+		}, []string{"version"}),
+		ConfVersion: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "nanotube",
+			Name:      "conf_version",
+			Help:      "Config version in label. Value should be always 1.",
+		}, []string{"conf_version"}),
 	}
 }
 
@@ -182,6 +188,11 @@ func Register(m *Prom, cfg *conf.Main) {
 	err = prometheus.Register(m.Version)
 	if err != nil {
 		log.Fatalf("error registering the version metric: %v", err)
+	}
+
+	err = prometheus.Register(m.ConfVersion)
+	if err != nil {
+		log.Fatalf("error registering the conf version metric: %v", err)
 	}
 
 	if !cfg.LessMetrics {


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #72 

## How does this change solve the problem? Why is this the best approach?
MD5 hash on all configs. It's the shortest and unique enough.

## How can we be sure this works as expected?
Manual tests.

Note: This branch is on top of #89 