### PR TITLE
Disabled floating timestamp logging by default.

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -71,7 +71,7 @@ LBClusterHealthCheckPeriodSec = 10
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true
 # Turns on logging for special kinds of records. For now it's recrods with fractional timestamps.
-LogSpecialRecords = true
+LogSpecialRecords = false
 
 # Profiling port. Skip to disable.
 PprofPort = 6000

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -115,7 +115,7 @@ func MakeDefault() Main {
 		TCPOutConnectionRefreshPeriodSec: 0,
 
 		NormalizeRecords:  true,
-		LogSpecialRecords: true,
+		LogSpecialRecords: false,
 
 		PprofPort:           -1,
 		PromPort:            9090,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -60,7 +60,7 @@ func TestConfSimple(t *testing.T) {
 		HostReconnectPeriodDeltaMs:    13,
 
 		NormalizeRecords:  true,
-		LogSpecialRecords: true,
+		LogSpecialRecords: false,
 
 		PprofPort: -1,
 		PromPort:  9090,


### PR DESCRIPTION
## What issue is this change attempting to solve?
Too much unnecessary logs.

Relates to #91 