### PR TITLE
NaN is not recognized as a valid metric value now.

### DIFF
--- a/pkg/rec/rec.go
+++ b/pkg/rec/rec.go
@@ -3,6 +3,7 @@ package rec
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,9 @@ func ParseRec(s string, normalize bool, shouldLog bool, nowF func() time.Time, l
 	val, err := strconv.ParseFloat(words[1], 64)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error converting incoming record val %s", words[1])
+	}
+	if math.IsNaN(val) {
+		return nil, errors.New("got NaN value for metric")
 	}
 
 	var tm uint64

--- a/pkg/rec/rec_test.go
+++ b/pkg/rec/rec_test.go
@@ -153,6 +153,10 @@ func TestRec(t *testing.T) {
 				RawTime: "0",
 			},
 		},
+		{
+			s:     "a.b.c NaN 12345",
+			isErr: true,
+		},
 	}
 	nowF := func() time.Time {
 		return time.Time{}


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #68 
