### PR TITLE
Use stale connection refresh instead of LB healthcheck.

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -65,8 +65,6 @@ TCPOutConnectionRefreshPeriodSec = 0
 MaxHostReconnectPeriodMs = 5000
 # Parameter for exponential backoffs during reconnects
 HostReconnectPeriodDeltaMs = 10
-# LB cluster health check period
-LBClusterHealthCheckPeriodSec = 10
 
 # Turns on and off the normalization of records path. Described in the docs in detail.
 NormalizeRecords = true
@@ -74,7 +72,7 @@ NormalizeRecords = true
 LogSpecialRecords = false
 
 # Absolute path for a pidfile. Not written if left empty.
-PidFilePath = "/home/rgrytskiv/nt.pid"
+PidFilePath = ""
 
 # Profiling port. Skip to disable.
 PprofPort = 6000

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -30,14 +30,13 @@ type Main struct {
 
 	WorkerPoolSize uint16
 
-	IncomingConnIdleTimeoutSec    uint32
-	SendTimeoutSec                uint32
-	OutConnTimeoutSec             uint32
-	MaxHostReconnectPeriodMs      uint32
-	LBClusterHealthCheckPeriodSec uint32
-	HostReconnectPeriodDeltaMs    uint32
-	KeepAliveSec                  uint32
-	TermTimeoutSec                uint16
+	IncomingConnIdleTimeoutSec uint32
+	SendTimeoutSec             uint32
+	OutConnTimeoutSec          uint32
+	MaxHostReconnectPeriodMs   uint32
+	HostReconnectPeriodDeltaMs uint32
+	KeepAliveSec               uint32
+	TermTimeoutSec             uint16
 	// 0 value turns off buffering
 	TCPOutBufSize int
 	// 0 value turns off flushing
@@ -114,7 +113,6 @@ func MakeDefault() Main {
 		SendTimeoutSec:                   5,
 		OutConnTimeoutSec:                5,
 		MaxHostReconnectPeriodMs:         5000,
-		LBClusterHealthCheckPeriodSec:    10,
 		HostReconnectPeriodDeltaMs:       10,
 		KeepAliveSec:                     1,
 		TermTimeoutSec:                   10,

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -29,7 +29,6 @@ func TestConfSimple(t *testing.T) {
 	TCPOutBufFlushPeriodSec = 3
 	KeepAliveSec = 3
 	MaxHostReconnectPeriodMs = 777
-	LBClusterHealthCheckPeriodSec = 18
 	HostReconnectPeriodDeltaMs = 13
 	ConnectionLossThresholdMs = 200`
 
@@ -48,16 +47,15 @@ func TestConfSimple(t *testing.T) {
 
 		WorkerPoolSize: 10,
 
-		IncomingConnIdleTimeoutSec:    13,
-		SendTimeoutSec:                7,
-		OutConnTimeoutSec:             9,
-		TermTimeoutSec:                11,
-		TCPOutBufSize:                 11,
-		TCPOutBufFlushPeriodSec:       3,
-		KeepAliveSec:                  3,
-		MaxHostReconnectPeriodMs:      777,
-		LBClusterHealthCheckPeriodSec: 18,
-		HostReconnectPeriodDeltaMs:    13,
+		IncomingConnIdleTimeoutSec: 13,
+		SendTimeoutSec:             7,
+		OutConnTimeoutSec:          9,
+		TermTimeoutSec:             11,
+		TCPOutBufSize:              11,
+		TCPOutBufFlushPeriodSec:    3,
+		KeepAliveSec:               3,
+		MaxHostReconnectPeriodMs:   777,
+		HostReconnectPeriodDeltaMs: 13,
 
 		NormalizeRecords:  true,
 		LogSpecialRecords: false,

--- a/pkg/target/cluster.go
+++ b/pkg/target/cluster.go
@@ -3,7 +3,6 @@ package target
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
 	"github.com/bookingcom/nanotube/pkg/metrics"
@@ -114,18 +113,6 @@ func (cl *Cluster) Send(cwg *sync.WaitGroup, finish chan struct{}) {
 			close(h.Ch)
 		}
 	}()
-}
-
-// TODO: Move this to host.
-func (cl *Cluster) updateAvailableHostsPeriodically(d time.Duration) {
-	t := time.NewTicker(d)
-	defer t.Stop()
-
-	for ; true; <-t.C {
-		for _, h := range cl.Hosts {
-			go h.checkUpdateHostStatus()
-		}
-	}
 }
 
 // hashing for the rind of hosts in a cluster based on the record path

--- a/pkg/target/clusters.go
+++ b/pkg/target/clusters.go
@@ -3,7 +3,6 @@ package target
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/bookingcom/nanotube/pkg/conf"
 	"github.com/bookingcom/nanotube/pkg/metrics"
@@ -62,11 +61,6 @@ func NewClusters(mainCfg conf.Main, cfg conf.Clusters, lg *zap.Logger, ms *metri
 		cls[cl.Name] = cl
 	}
 
-	for _, cl := range cls {
-		if cl.Type == conf.LB {
-			go cl.updateAvailableHostsPeriodically(time.Duration(mainCfg.LBClusterHealthCheckPeriodSec) * time.Second)
-		}
-	}
 	return cls, err
 }
 

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -266,20 +266,3 @@ func (h *Host) getConnectionToHost() (net.Conn, error) {
 	conn, err := dialer.Dial("tcp", net.JoinHostPort(h.Name, fmt.Sprint(h.Port)))
 	return conn, err
 }
-
-func (h *Host) checkUpdateHostStatus() {
-	// TODO: Logic here is different from Connect function. Fix error handling.
-	conn, _ := h.getConnectionToHost()
-	if conn != nil {
-		h.Available.Store(true)
-		err := conn.Close()
-		if err != nil {
-			h.Lg.Warn("failed to close the LB probe connection", zap.Error(err))
-		}
-	} else {
-		if h.Available.CAS(true, false) { // CAS = compare-and-save
-			h.stateChanges.Inc()
-			h.stateChangesTotal.Inc()
-		}
-	}
-}


### PR DESCRIPTION
## What issue is this change attempting to solve?
#106 

## How does this change solve the problem? Why is this the best approach?
We can simply remove LB health-check while keeping connection refresh on. 

## How can we be sure this works as expected?
manual tests