### PR TITLE
small cosmetic fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .PHONY: all
-all:
+all: build
+
+.PHONY: build
+build:
 	go build -ldflags "-X main.version=$(shell git rev-parse HEAD)" ./cmd/nanotube
 
+.PHONY: race
 race:
 	go build -race -ldflags "-X main.version=$(shell git rev-parse HEAD)" ./cmd/nanotube
 


### PR DESCRIPTION
. fix missing PHONY
. have `all` redirect to the `build` target, `all` shouldn't do actually anything by itself 