### PR TITLE
Removed automaxprocs.

### DIFF
--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -11,6 +11,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/facebookgo/grace/gracenet"
 	"github.com/libp2p/go-reuseport"
-	_ "go.uber.org/automaxprocs" // TODO: Make explicit. Remove logline.
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -66,6 +66,9 @@ func main() {
 
 	ms := metrics.New(&cfg)
 	metrics.Register(ms, &cfg)
+
+	lg.Info("GOMAXPROCS value", zap.Int("GOMAXPROCS", runtime.GOMAXPROCS(0)))
+
 	clusters, rules, rewrites, err := buildPipeline(&cfg, &clustersConf, &rulesConf, rewritesConf, ms, lg)
 	if err != nil {
 		log.Fatalf("error building pipline components: %v", err)


### PR DESCRIPTION
## What issue is this change attempting to solve?
* NT mostly runs on on-prem, this library has no effect there
* in the cases we do run NT in containers, e.g. on k8s, the library detects the number of CPU cores incorrectly
* it _may_ be relevant in case of a sidecar, but these case are mostly irrelevant as they do not have high load
* we do not use it to set critical concurrency parameters
* it is global and cannot be properly set-up
* it breaks the format of our logs and this cannot be corrected
* it is not actively maintained at the moment

## How can we be sure this works as expected?
Tested on real-life boxes.