### PR TITLE
observability: add rewrite_match_records metric

### DIFF
--- a/cmd/nanotube/process.go
+++ b/cmd/nanotube/process.go
@@ -54,7 +54,7 @@ func proc(s []byte, rules rules.Rules, rewrites rewrites.Rewrites, shouldNormali
 		return
 	}
 
-	recs, err := rewrites.RewriteMetricBytes(r)
+	recs, err := rewrites.RewriteMetricBytes(r, metrics)
 	if err != nil {
 		lg.Info("Error parsing incoming record", zap.String("record", string(s)), zap.Error(err))
 		return

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,6 +49,8 @@ type Prom struct {
 
 	RegexDuration *prometheus.SummaryVec
 
+	RewriteMatchRecords prometheus.Counter
+
 	Version     *prometheus.CounterVec
 	ConfVersion *prometheus.CounterVec
 }
@@ -184,6 +186,11 @@ func New(conf *conf.Main) *Prom {
 			Name:      "regex_duration_seconds",
 			Help:      "Time to evaluate each regex from configuration",
 		}, []string{"regex", "rule_type"}),
+		RewriteMatchRecords: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "nanotube",
+			Name:      "rewrite_match_records_total",
+			Help:      "Number of metics that were matched by any of the rewrite rules",
+		}),
 		Version: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "nanotube",
 			Name:      "version",

--- a/pkg/rewrites/rewrites.go
+++ b/pkg/rewrites/rewrites.go
@@ -79,7 +79,7 @@ func (rw Rewrites) compile() error {
 
 // RewriteMetricBytes executes all rewrite rules on a record
 // If copy is true and rule matches, we generate new record
-func (rw Rewrites) RewriteMetricBytes(record *rec.RecBytes) ([]*rec.RecBytes, error) {
+func (rw Rewrites) RewriteMetricBytes(record *rec.RecBytes, metrics *metrics.Prom) ([]*rec.RecBytes, error) {
 	var timer *prometheus.Timer
 
 	result := []*rec.RecBytes{record}
@@ -93,6 +93,7 @@ func (rw Rewrites) RewriteMetricBytes(record *rec.RecBytes) ([]*rec.RecBytes, er
 			timer.ObserveDuration()
 		}
 		if matched {
+			metrics.RewriteMatchRecords.Inc()
 			if rw.measureRegex {
 				timer = prometheus.NewTimer(r.replaceDuration)
 			}

--- a/pkg/rewrites/rewrites_test.go
+++ b/pkg/rewrites/rewrites_test.go
@@ -60,7 +60,7 @@ func TestRewrites(t *testing.T) {
 		record := &rec.RecBytes{
 			Path: test.in,
 		}
-		resultRecords, err := rewrites.RewriteMetricBytes(record)
+		resultRecords, err := rewrites.RewriteMetricBytes(record, ms)
 		if err != nil {
 			t.Error("could not rewrite record")
 		}


### PR DESCRIPTION
## What issue is this change attempting to solve?
nanotube allow to perform rewrites of incoming records
Currently there is no visibility over utilisation of this functionality
Fixes #157

## How does this change solve the problem? Why is this the best approach?
This commit is adding rewrite_match_records prometheus
counter in order to gain visibility over rewrite rules
usage. The counter increases on every rewrite rule match
and does not track actual actions performed with matched
record.
