### PR TITLE
Added metric to track targets config version.

### DIFF
--- a/cmd/nanotube/main_test.go
+++ b/cmd/nanotube/main_test.go
@@ -45,7 +45,7 @@ func setup(t *testing.T) {
 
 	cfgPath := filepath.Join(fixturesPath, "config.toml")
 
-	cfg, clustersConf, rulesConf, rewritesConf, _, err := readConfigs(cfgPath)
+	cfg, clustersConf, rulesConf, rewritesConf, _, _, err := readConfigs(cfgPath)
 	if err != nil {
 		t.Fatalf("error reading and compiling config: %v", err)
 	}

--- a/cmd/nanotube/process_test.go
+++ b/cmd/nanotube/process_test.go
@@ -256,7 +256,7 @@ func setupRealisticBench(b *testing.B) (benchMetrics []string, clusters target.C
 
 	cfgPath := filepath.Join(fixturesPath, "config.toml")
 
-	cfg, clustersConf, rulesConf, rewritesConf, _, err := readConfigs(cfgPath)
+	cfg, clustersConf, rulesConf, rewritesConf, _, _, err := readConfigs(cfgPath)
 	if err != nil {
 		b.Fatalf("error reading and compiling config: %v", err)
 	}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -262,3 +262,13 @@ func Hash(cfg *Main, clusters *Clusters, rules *Rules, rewrites *Rewrites) (stri
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
+
+// ClustersHash calculates hash of the clusters config to track its versions.
+func ClustersHash(clusters *Clusters) (string, error) {
+	h := md5.New()
+	_, err := h.Write([]byte(fmt.Sprintf("%v", clusters)))
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate clusters config hash: %w", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -49,8 +49,9 @@ type Prom struct {
 
 	RegexDuration *prometheus.SummaryVec
 
-	Version     *prometheus.CounterVec
-	ConfVersion *prometheus.CounterVec
+	Version         *prometheus.CounterVec
+	ConfVersion     *prometheus.CounterVec
+	ClustersVersion *prometheus.CounterVec
 }
 
 // New creates a new set of metrics from the main config.
@@ -194,6 +195,11 @@ func New(conf *conf.Main) *Prom {
 			Name:      "conf_version",
 			Help:      "Config version in label. Value should be always 1.",
 		}, []string{"conf_version"}),
+		ClustersVersion: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "nanotube",
+			Name:      "clusters_version",
+			Help:      "Clusters config version in label. Value should be always 1.",
+		}, []string{"clusters_version"}),
 	}
 }
 
@@ -253,6 +259,11 @@ func Register(m *Prom, cfg *conf.Main) {
 	err = prometheus.Register(m.ConfVersion)
 	if err != nil {
 		log.Fatalf("error registering the conf version metric: %v", err)
+	}
+
+	err = prometheus.Register(m.ClustersVersion)
+	if err != nil {
+		log.Fatalf("error registering the clusters_version metric: %v", err)
 	}
 
 	if !cfg.LessMetrics {


### PR DESCRIPTION
Exposed clusters config hash metric to track the changes specifically in the targets setup.
Useful to e.g. to track service discovery mechanisms.