### PR TITLE
fix path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Is defined in the [rules config](config/rules.toml) that is in turn referred to 
   - If no regex or prefix matches, continue down the list of rules;
 - Multiple rules can be matched to each record;
 - Each record is sent to a single cluster only once. If two rules send it to same cluster, only one instance will be sent;
-- Cluster names must be from the set in the [clusters config](clonfig/clusters.toml).
+- Cluster names must be from the set in the [clusters config](config/clusters.toml).
 
 ### Rewrites
 


### PR DESCRIPTION
## What issue is this change attempting to solve?
typo in path to config/clusters.toml

## How does this change solve the problem? Why is this the best approach?
makes the link work.

## How can we be sure this works as expected?
look at it :)