### PR TITLE
Added jitter to target connection with TCP.

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -97,6 +97,11 @@ type Main struct {
 	// Perform connection check to target right away?
 	TCPInitialConnCheck bool
 
+	// Enable jitter when connecting to targets?
+	TargetConnectionJitter bool
+	// Minimal amplitude when adding jitter to target connections. Has to be >0.
+	TargetConnectionJitterMinAmplitudeMs uint32
+
 	// gRPC target (client) params
 	// gRPC HTTP2 keepalive ping period https://github.com/grpc/grpc-go/blob/master/Documentation/keepalive.md
 	GRPCOutKeepAlivePeriodSec      uint32
@@ -177,6 +182,9 @@ func ReadMain(r io.Reader) (Main, error) {
 			return cfg, errors.New("pidfile path is not valid or not an absolute path")
 		}
 	}
+	if cfg.TargetConnectionJitterMinAmplitudeMs == 0 {
+		return cfg, errors.New("TargetConnectionJitterMinAmplitudeMs is 0")
+	}
 
 	return cfg, nil
 }
@@ -215,7 +223,8 @@ func MakeDefault() Main {
 		TCPOutBufSize:                    0,
 		TCPOutBufFlushPeriodSec:          2,
 		TCPOutConnectionRefreshPeriodSec: 0,
-		TCPInitialConnCheck:              false,
+
+		TargetConnectionJitterMinAmplitudeMs: 200,
 
 		GRPCOutKeepAlivePeriodSec:      5,
 		GRPCOutKeepAlivePingTimeoutSec: 1,
@@ -231,8 +240,7 @@ func MakeDefault() Main {
 
 		GRPCTracing: true,
 
-		NormalizeRecords:  true,
-		LogSpecialRecords: false,
+		NormalizeRecords: true,
 
 		PprofPort:           -1,
 		PromPort:            9090,

--- a/pkg/target/hostTCP.go
+++ b/pkg/target/hostTCP.go
@@ -6,13 +6,13 @@ import (
 	"go.uber.org/zap"
 )
 
-// HostTCP will represent TCP host
-// It's a stub for now, it's role is currently carried out by Host struct
+// HostTCP will represent TCP host.
+// It's a stub for now, its role is currently carried out by the Host struct.
 type HostTCP struct {
 	Host
 }
 
-// NewHostTCP ...
+// NewHostTCP constructs a new TCP target host.
 func NewHostTCP(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg *zap.Logger, ms *metrics.Prom) *HostTCP {
 	return &HostTCP{*ConstructHost(clusterName, mainCfg, hostCfg, lg, ms)}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #32 

## How does this change solve the problem? Why is this the best approach?
Inspiration comes mainly from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ as suggested in the issue.

## How can we be sure this works as expected?
Basic manual tests.