### PR TITLE
Safeguarded indexing of normalized path slices.

### DIFF
--- a/pkg/rec/rec_bytes.go
+++ b/pkg/rec/rec_bytes.go
@@ -125,7 +125,7 @@ func normalizePathBytes(s []byte) ([]byte, error) {
 		return []byte{}, errors.New("path contains only dots")
 	}
 
-	end := len(s) - 1 // points to the last char in path
+	end := len(s) - 1 // points to the last non-. char in path
 	for ; end >= start && s[end] == '.'; end-- {
 	}
 	// check for string consisting only of points was done above
@@ -133,7 +133,10 @@ func normalizePathBytes(s []byte) ([]byte, error) {
 	needsNormalization := false
 	for i := start; i <= end; i++ {
 		if s[i] == '.' {
-			if s[i+1] == '.' { // safe, a dot cannot be the last
+			if i == len(s)-1 {
+				needsNormalization = true
+				break
+			} else if s[i+1] == '.' {
 				needsNormalization = true
 				break
 			}
@@ -149,8 +152,9 @@ func normalizePathBytes(s []byte) ([]byte, error) {
 	if needsNormalization {
 		for i := start; i <= end; i++ {
 			if s[i] == '.' {
-				// a dot cannot be the last char
-				if s[i+1] == '.' {
+				if i == len(s)-1 {
+					continue
+				} else if s[i+1] == '.' {
 					continue
 				}
 			}

--- a/pkg/rec/rec_test.go
+++ b/pkg/rec/rec_test.go
@@ -196,6 +196,7 @@ func TestNormalization(t *testing.T) {
 	tt := []struct {
 		in  string
 		out string
+		err bool
 	}{
 		{
 			in:  "a.b.c",
@@ -237,12 +238,45 @@ func TestNormalization(t *testing.T) {
 			in:  "ab^%+=.cdef.jk&",
 			out: "ab____.cdef.jk_",
 		},
+		{
+			in:  "a.",
+			out: "a",
+		},
+		{
+			in:  ".",
+			out: "",
+			err: true,
+		},
+		{
+			in:  "...",
+			out: "",
+			err: true,
+		},
+		{
+			in:  ".a.",
+			out: "a",
+		},
+		{
+			in:  ".a.b.c",
+			out: "a.b.c",
+		},
+		{
+			in:  "",
+			out: "",
+		},
+		{
+			in:  "...-..-..-.",
+			out: "-.-.-",
+		},
 	}
 
 	for _, test := range tt {
 		s, err := normalizePathBytes([]byte(test.in))
-		if err != nil {
-			t.Fatalf("got error while normalizing: %v", err)
+		if err != nil && !test.err {
+			t.Fatalf("got unexpected error while normalizing: %v", err)
+		}
+		if err == nil && test.err {
+			t.Fatalf("no error when error expected, record: %s", test.in)
 		}
 		if string(s) != test.out {
 			t.Fatalf("Got %s after normalization of %s, expected %s", s, test.in, test.out)


### PR DESCRIPTION
## What issue is this change attempting to solve?
Makes edge cases of indexing more safe. 

We should also consider additional fuzzy tests to find edge cases.