### PR TITLE
Disabled warnings of requests containing semicolons

### DIFF
--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -97,7 +97,7 @@ func main() {
 		if err != nil {
 			lg.Error("opening TCP port for Prometheus failed", zap.Error(err))
 		}
-		err = http.Serve(l, promhttp.Handler())
+		err = http.Serve(l, http.AllowQuerySemicolons(promhttp.Handler()))
 		if err != nil {
 			lg.Error("Prometheus server failed", zap.Error(err))
 		}


### PR DESCRIPTION
Added AllowQuerySemicolons middleware which converts any semicolons in the URL query to ampersands. 
Fixes the issue https://github.com/bookingcom/nanotube/issues/166
