### PR TITLE
added config cluster index check only for jump hash cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ test/performance/hosts.yaml
 test/performance/run-sender.sh
 test/performance/setup.yaml
 test/performance/roles/prometheus/files/prometheus
+/local/config/clusters.toml
+/local/config/config.toml
+/local/config/rules.toml

--- a/pkg/conf/clusters.go
+++ b/pkg/conf/clusters.go
@@ -75,20 +75,21 @@ func ReadClustersConfig(r io.Reader) (Clusters, error) {
 		if len(cluster.Hosts) == 0 && cluster.Type != BlackholeCluster {
 			return cls, fmt.Errorf("cluster with index %d does not have any hosts", idx)
 		}
+		if cluster.Type == JumpCluster {
+			inxs := map[int]bool{}
+			for _, host := range cluster.Hosts {
+				if host.Name == "" {
+					return cls, fmt.Errorf("host %d in cluster does not have a name", idx)
+				}
 
-		inxs := map[int]bool{}
-		for _, host := range cluster.Hosts {
-			if host.Name == "" {
-				return cls, fmt.Errorf("host %d in cluster does not have a name", idx)
+				if host.Index < 0 || host.Index >= len(cluster.Hosts) {
+					return cls, fmt.Errorf("host %s index is %d; it is out of bounds in cluster %s", host.Name, host.Index, cluster.Name)
+				}
+				if inxs[host.Index] {
+					return cls, fmt.Errorf("duplicate host index %d in cluster %s", host.Index, cluster.Name)
+				}
+				inxs[host.Index] = true
 			}
-
-			if host.Index < 0 || host.Index >= len(cluster.Hosts) {
-				return cls, fmt.Errorf("host %s index is %d; it is out of bounds in cluster %s", host.Name, host.Index, cluster.Name)
-			}
-			if inxs[host.Index] {
-				return cls, fmt.Errorf("duplicate host index %d in cluster %s", host.Index, cluster.Name)
-			}
-			inxs[host.Index] = true
 		}
 	}
 	return cls, nil


### PR DESCRIPTION
## What issue is this change attempting to solve?
When we had config for LB clusters without specified index ReadClustersConfig function failed and the process failed. 
 
## How does this change solve the problem? Why is this the best approach?
We should perform the check only for Jump hash clusters, because for LB, ToallCluster, BlackholeCluster the index doesn't make sense 
## How can we be sure this works as expected?
tested ob local machine