### PR TITLE
Fix active conn metric increase on accept error

### DIFF
--- a/pkg/in/tcp.go
+++ b/pkg/in/tcp.go
@@ -24,12 +24,12 @@ loop:
 		go func() {
 			conn, err := l.Accept()
 
-			ms.ActiveTCPConnections.Inc()
-			ms.InConnectionsTotalTCP.Inc()
-
 			if err != nil {
 				errCh <- err
 			} else {
+				ms.ActiveTCPConnections.Inc()
+				ms.InConnectionsTotalTCP.Inc()
+
 				connCh <- conn
 			}
 		}()


### PR DESCRIPTION
If accept returns an error, we should not increase the active conn metric and total tcp connections.
