### PR TITLE
Moved linter config to a file instead of command flags.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2
-          args: -E gofmt -E gochecknoglobals -E unparam -E misspell --exclude-use-default=false --timeout 5m0s ./...
       - name: test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+run:
+  timeout: 2m
+  tests: true
+
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - gochecknoinits
+    - gofmt
+    - goimports
+    - misspell
+    - unparam
+    - gochecknoglobals
+
+# Enable in the future
+    # - gosec
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  # exclude-rules:
+    # Exclude some linters from running on tests files.
+    # - path:
+    #   linters:
+    #     - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
-  timeout: 2m
-  tests: true
+  timeout: 3m
+  tests: false
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run -E gofmt -E gochecknoglobals -E unparam -E misspell --exclude-use-default=false --timeout 5m0s ./...
+# golangci-lint run -E gofmt -E gochecknoglobals -E unparam -E misspell --exclude-use-default=false --timeout 2m0s ./...
+	golangci-lint run
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
Resolves #204 

Removed tests linting for now because on slow GitHub runners the linting sometimes takes more than 2 minutes.
