### PR TITLE
MultiTCP transport implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v3
       - name: golangci-lint
-        if: matrix.go-version == 'tip'
-        uses: golangci/golangci-lint-action@v3
+        if: matrix.go-version == '1.22.x'
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.0
+          version: v1.59
       - name: test
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.20.x, 1.21.x, tip ]
+        go-version: [ 1.20.x, 1.21.x, 1.22.x, tip ]
     steps:
       - name: Set up Go stable
         if: matrix.go-version != 'tip'
@@ -15,18 +15,18 @@ jobs:
       - name: Set up Go tip
         if: matrix.go-version == 'tip'
         run: |
-          curl -sL https://storage.googleapis.com/go-build-snap/go/linux-amd64/$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}').tar.gz -o gotip.tar.gz
-          ls -lah gotip.tar.gz
-          mkdir -p ~/sdk/gotip
-          tar -C ~/sdk/gotip -xzf gotip.tar.gz
-          ~/sdk/gotip/bin/go version
+          curl -o go.tar.gz -L \
+          https://github.com/AlekSi/golang-tip/releases/download/tip/master.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go.tar.gz
+          sudo ln -s /usr/local/go/bin/* /usr/local/bin/
+          /usr/local/bin/go version
           echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
       - name: checkout code
         uses: actions/checkout@v3
       - name: golangci-lint
-        if: matrix.go-version == '1.21.x'
+        if: matrix.go-version == 'tip'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.59.0
       - name: test
         run: make test

--- a/pkg/conf/clusters.go
+++ b/pkg/conf/clusters.go
@@ -52,6 +52,8 @@ type Host struct {
 	Port uint16 `toml:"port"`
 	// Optional, TCP by default
 	GRPC bool `toml:"grpc"`
+	// Optional,
+	MTCP int `toml:"mtcp"`
 }
 
 // ReadClustersConfig reads clusters set from a reader.

--- a/pkg/conf/clusters.go
+++ b/pkg/conf/clusters.go
@@ -52,7 +52,7 @@ type Host struct {
 	Port uint16 `toml:"port"`
 	// Optional, TCP by default
 	GRPC bool `toml:"grpc"`
-	// Optional,
+	// Optional, number of TCP connections to open to the host.
 	MTCP int `toml:"mtcp"`
 }
 

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -190,20 +190,13 @@ func (h *HostMTCP) Stream(wg *sync.WaitGroup) {
 		close(h.stop)
 	}()
 
+	// send records from the channel to every connection in round robin fashion
+	i := 0
 	for r := range h.Ch {
-		i := 0
 		h.tryToSend(r, &h.MTCPs[i])
 		i++
-	LOOP:
-		// For control maximum size of batch
-		for i < h.NumMTCP {
-			select {
-			case r := <-h.Ch:
-				h.tryToSend(r, &h.MTCPs[i])
-				i++
-			default:
-				break LOOP
-			}
+		if i == h.NumMTCP {
+			i = 0
 		}
 	}
 

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -251,11 +251,9 @@ func (h *HostMTCP) flush(d time.Duration) {
 		case <-h.stop:
 			return
 		case <-t.C:
-			for c := range h.MTCPs {
-				h.MTCPs[c].Lock()
-				h.tryToFlushIfNecessary()
-				h.MTCPs[c].Unlock()
-			}
+			h.LockMTCP()
+			h.tryToFlushIfNecessary()
+			h.UnlockMTCP()
 		}
 	}
 }

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -148,7 +148,7 @@ func (h *HostMTCP) Push(r *rec.RecBytes) {
 	default:
 		h.throttled.Inc()
 		h.throttledTotal.Inc()
-		h.Lg.Warn("host queue is full", zap.Int("queue_size", len(h.Ch)))
+		//h.Lg.Warn("host queue is full", zap.Int("queue_size", len(h.Ch)))
 	}
 }
 

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -216,7 +216,7 @@ func (h *HostMTCP) tryToSend(r *rec.RecBytes, conn *MultiConnection) {
 		h.ensureConnection()
 		h.keepConnectionFresh()
 
-		err := conn.Conn.SetWriteDeadline(time.Now().Add(
+		err := conn.SetWriteDeadline(time.Now().Add(
 			time.Duration(h.conf.SendTimeoutSec) * time.Second))
 		if err != nil {
 			h.Lg.Warn("error setting write deadline", zap.Error(err))

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -233,7 +233,7 @@ func (h *HostMTCP) tryToSend(r *rec.RecBytes, conn *MultiConnection) {
 		}
 
 		h.Lg.Warn("error sending value to host. Reconnect and retry..", zap.Error(err))
-		err = conn.Conn.Close()
+		err = conn.Close()
 		if err != nil {
 			// not retrying here, file descriptor may be lost
 			h.Lg.Error("error closing the connection", zap.Error(err))

--- a/pkg/target/hostMTCP.go
+++ b/pkg/target/hostMTCP.go
@@ -69,6 +69,9 @@ func (c *MultiConnection) New(conn net.Conn, bufSize int) {
 // Overrides c.Conn.Close().
 // Use instead the default close.
 func (c *MultiConnection) Close() error {
+	if c.Conn == nil {
+		return nil
+	}
 	err := c.Conn.Close()
 	c.Conn = nil
 


### PR DESCRIPTION
## What issue is this change attempting to solve?

Not Nanotube issue, but go-carbon issue per se. I found out that all readers in go-carbon are quite limited in performance of single connection. Maybe that can be fixed by doing records parsing in separate goroutines as carbon-clickhouse does. Anyway, that's a quick hack to fix that issue for now, because Nanotube is hi-performance tool and would provide fixes for performance issues. :)

## How does this change solve the problem? Why is this the best approach?

I'm introducing new transport named MTCP - multi TCP. If you using `mtcp` parameter > 1 if host config then cluster host will use `HostMTCP` instance instead of usual `HostTCP`.  HostMTCP would open `mtcp` number of TCP connections to destination host and will stream metrics to all these connections. So, I'm quite confident that this change would not affect usual hosts and usual functionality, which remain untouched.

## How can we be sure this works as expected?

I did some testing, but probably we would need some serious e2e testing here, which I currently avoided. As I said above, I beleive that change is quite isolated and should not affect basic functionality.
