### PR TITLE
Adding host queue size metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,6 +36,7 @@ type Prom struct {
 	TargetStates             *prometheus.GaugeVec
 	NumberOfAvailableTargets *prometheus.GaugeVec
 	NumberOfTargets          *prometheus.GaugeVec
+	HostQueueSize            *prometheus.GaugeVec
 
 	GlobalRateLimiterBlockedReaders    prometheus.Counter
 	ContainerRateLimiterBlockedReaders *prometheus.CounterVec
@@ -143,6 +144,11 @@ func New() *Prom {
 			Namespace: "nanotube",
 			Name:      "target_states",
 			Help:      "The current states of target hosts.",
+		}, []string{"upstream_host", "cluster"}),
+		HostQueueSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "nanotube",
+			Name:      "host_queue_size",
+			Help:      "The current size of host queue.",
 		}, []string{"upstream_host", "cluster"}),
 		NumberOfAvailableTargets: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "nanotube",
@@ -307,6 +313,11 @@ func Register(m *Prom, cfg *conf.Main) {
 		}
 
 		err = prometheus.Register(m.TargetStates)
+		if err != nil {
+			log.Fatalf("error while registering target_states metric: %v", err)
+		}
+
+		err = prometheus.Register(m.HostQueueSize)
 		if err != nil {
 			log.Fatalf("error while registering target_states metric: %v", err)
 		}

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -250,6 +250,7 @@ func (h *Host) tryToFlushIfNecessary() {
 		}
 		h.Conn.LastConnUse = time.Now()
 	}
+	h.hostQueueSize.Set(float64(len(h.Ch)))
 }
 
 // Requires h.Conn.Mutex lock.

--- a/pkg/target/host.go
+++ b/pkg/target/host.go
@@ -45,6 +45,7 @@ type Host struct {
 	stateChangesTotal         prometheus.Counter
 	oldConnectionRefresh      prometheus.Counter
 	oldConnectionRefreshTotal prometheus.Counter
+	hostQueueSize             prometheus.Gauge
 	targetState               prometheus.Gauge
 }
 
@@ -120,6 +121,7 @@ func ConstructHost(clusterName string, mainCfg conf.Main, hostCfg conf.Host, lg 
 		stateChangesTotal:         ms.StateChangeHostsTotal,
 		oldConnectionRefresh:      ms.OldConnectionRefresh.With(promLabels),
 		oldConnectionRefreshTotal: ms.OldConnectionRefreshTotal,
+		hostQueueSize:             ms.HostQueueSize.With(promLabels),
 		targetState:               ms.TargetStates.With(promLabels),
 	}
 	h.rnd = rand.New(rand.NewSource(time.Now().UnixNano()))


### PR DESCRIPTION
## What issue is this change attempting to solve?

Currently, we have no visibility on host queue size, only metrics for changing state and queue overflow (throttling). This PR adding this metric, with cluster and host labels.

