### PR TITLE
Added an option to expose Prometheus metrics locally.

### DIFF
--- a/cmd/nanotube/main.go
+++ b/cmd/nanotube/main.go
@@ -96,7 +96,11 @@ func main() {
 	}
 
 	go func() {
-		l, err := reuseport.Listen("tcp", fmt.Sprintf(":%d", cfg.PromPort))
+		addrHostPrefix := ""
+		if cfg.PromLocal {
+			addrHostPrefix = "127.0.0.1"
+		}
+		l, err := reuseport.Listen("tcp", fmt.Sprintf("%s:%d", addrHostPrefix, cfg.PromPort))
 		if err != nil {
 			lg.Error("opening TCP port for Prometheus failed", zap.Error(err))
 		}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -132,6 +132,8 @@ type Main struct {
 	// -1 turns off pprof server
 	PprofPort int
 	PromPort  int
+	// Expose the Prometheus metrics locally.
+	PromLocal bool
 	// Switch to expose only small subset of essential metrics.
 	// (Useful to reduce Prometheus load when running as a sidecar on many nodes in a large setup.)
 	LessMetrics bool


### PR DESCRIPTION
## What issue is this change attempting to solve?
Adds the ability to restrict Prometheus exposition to localhost.
