### PR TITLE
Adding govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.21.x, 1.22.x, 1.23.x, tip ]
+        go-version: [ 1.23.x, tip ]
     steps:
       - name: Set up Go stable
         if: matrix.go-version != 'tip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Set up Go tip
         if: matrix.go-version == 'tip'
         run: |
@@ -30,3 +31,10 @@ jobs:
           version: v1.61.0
       - name: test
         run: make test
+      - name: govulncheck
+        if: matrix.go-version != 'tip'
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ matrix.go-version }}
+          check-latest: true
+          go-package: ./...


### PR DESCRIPTION
## What issue is this change attempting to solve?

Run govulncheck on supported go versions for checking security status.
Removing old go versions from tests.
