### PR TITLE
Supporting relevant golang versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.23.x, 1.24.x, tip ]
+        go-version: [ 1.24.x, 1.25.x, tip ]
     steps:
       - name: Set up Go stable
         if: matrix.go-version != 'tip'
@@ -24,12 +24,12 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v5
       - name: golangci-lint
-        if: matrix.go-version == '1.24.x'
+        if: matrix.go-version == '1.25.x'
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1.6
       - name: govulncheck
-        if: matrix.go-version == '1.24.x'
+        if: matrix.go-version == '1.25.x'
         uses: golang/govulncheck-action@v1
         with:
           check-latest: true


### PR DESCRIPTION
## What issue is this change attempting to solve?

Pipeline is broken now because latest grpc module require golang 1.24

## How does this change solve the problem? Why is this the best approach?

We should support current and previous golang release as good practice.

## How can we be sure this works as expected?

Pipeline should be green :)
